### PR TITLE
feat: allow environment variables for services

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,9 +1,12 @@
+use std::collections::HashMap;
+
 use crate::config::{RegistryDetails, Service};
 
 #[derive(Clone, Debug)]
 pub struct Container {
     pub image: String,
     pub target_port: u16,
+    pub environment: Option<HashMap<String, String>>,
 }
 
 impl From<&Service> for Container {
@@ -11,6 +14,7 @@ impl From<&Service> for Container {
         Self {
             image: service.image.clone(),
             target_port: service.port,
+            environment: service.environment.clone(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::fs::File;
+use std::hash::{Hash, Hasher};
 use std::path::Path;
 
 use anyhow::Result;
@@ -19,7 +21,7 @@ impl Config {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
 pub struct Service {
     pub image: String,
     pub tag: String,
@@ -27,6 +29,14 @@ pub struct Service {
     pub replicas: u32,
     pub host: String,
     pub path_prefix: Option<String>,
+    pub environment: Option<HashMap<String, String>>,
+}
+
+impl Hash for Service {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.image.hash(state);
+        self.tag.hash(state);
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/docker/api.rs
+++ b/src/docker/api.rs
@@ -23,7 +23,10 @@ pub async fn create_and_start_on_random_port(
     let mut exposed_ports = HashMap::new();
     exposed_ports.insert(target_port, 0);
 
-    let id = client.create_container(&name, &exposed_ports).await?;
+    let id = client
+        .create_container(&name, &exposed_ports, &container.environment)
+        .await?;
+
     client.start_container(&id).await?;
 
     tracing::info!(%id, %name, %target_port, "Created and started a container");

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -70,6 +70,7 @@ impl Client {
         &self,
         image: &str,
         port_mapping: &HashMap<u16, u16>,
+        environment: &Option<HashMap<String, String>>,
     ) -> Result<String> {
         let uri = self.build_uri("/containers/create");
 
@@ -88,10 +89,13 @@ impl Client {
             port_bindings.insert(port_and_protocol, vec![binding]);
         }
 
+        let env = format_environment_variables(environment);
+
         let options = CreateContainerOptions {
             image: String::from(image),
             exposed_ports,
             host_config: HostConfig { port_bindings },
+            env,
         };
 
         tracing::info!(?options, "Creating a container");
@@ -164,4 +168,13 @@ impl Client {
 
         Ok(tcp_exposed_ports)
     }
+}
+
+fn format_environment_variables(environment: &Option<HashMap<String, String>>) -> Vec<String> {
+    let Some(environment) = environment else { return Vec::new() };
+
+    environment
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect()
 }

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -16,6 +16,7 @@ pub struct CreateContainerOptions {
     pub image: String,
     pub exposed_ports: HashMap<String, EmptyMap>,
     pub host_config: HostConfig,
+    pub env: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/load_balancer/mod.rs
+++ b/src/load_balancer/mod.rs
@@ -76,6 +76,8 @@ impl LoadBalancer {
             let container = Container {
                 image: service.image.clone(),
                 target_port: service.port,
+                // TODO: this doesn't need this, the auto-reloading should take something different
+                environment: service.environment.clone(),
             };
 
             let current_tag = service.tag.clone();


### PR DESCRIPTION
Currently, you can define a Postgres container on a given tag and it will start up before immediately crashing. This is because the runtime expects a `POSTGRES_PASSWORD` to be defined but the API is not providing one to the container.

Instead, we can allow an optional environment to be passed alongside the service definition and pass this down to the `CreateContainer` object that is sent over to Docker. This allows the container to start correctly.

This change:
* Adds an optional `environment` section to the service configuration
* Passes this down when we create the container

Closes #1.
