### PR TITLE
feat: add auxillary services

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::config::{RegistryDetails, Service};
+use crate::config::{AuxillaryService, RegistryDetails, Service};
 
 #[derive(Clone, Debug)]
 pub struct Container {
@@ -11,6 +11,16 @@ pub struct Container {
 
 impl From<&Service> for Container {
     fn from(service: &Service) -> Self {
+        Self {
+            image: service.image.clone(),
+            target_port: service.port,
+            environment: service.environment.clone(),
+        }
+    }
+}
+
+impl From<&AuxillaryService> for Container {
+    fn from(service: &AuxillaryService) -> Self {
         Self {
             image: service.image.clone(),
             target_port: service.port,

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 pub struct Config {
     pub registry: RegistryDetails,
     pub services: Vec<Service>,
+    pub auxillary_services: Vec<AuxillaryService>,
 }
 
 impl Config {
@@ -37,6 +38,14 @@ impl Hash for Service {
         self.image.hash(state);
         self.tag.hash(state);
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+pub struct AuxillaryService {
+    pub image: String,
+    pub tag: String,
+    pub port: u16,
+    pub environment: Option<HashMap<String, String>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/load_balancer/mod.rs
+++ b/src/load_balancer/mod.rs
@@ -116,8 +116,7 @@ async fn check_for_newer_images(
             tracing::info!(%tag, "Found a new tag in the Docker registry");
 
             // Boot the new container
-            let binding =
-                docker::api::create_and_start_on_random_port(container, registry, &tag).await?;
+            let binding = docker::api::create_and_start_on_random_port(container, &tag).await?;
 
             tracing::info!(%binding, "Started a new container with the new tag");
         }


### PR DESCRIPTION
Some services don't particularly fit into the load balancing approach, since they're not meant to receive traffic directly. This is true of services like Postgres or Redis, which perform more of an auxillary role in operations and receive traffic from services in the load balanced pool.

These likely don't run more than 1 replica (for now) and also don't need a `Host` since they won't be load balanced.

This change:
* Adds a new `AuxillaryService` type
* Sets up all the auxillary services on startup
* Cleans up the registry configuration a little
