### PR TITLE
refactor: remove registries

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::config::{AuxillaryService, RegistryDetails, Service};
+use crate::config::{AuxillaryService, Service};
 
 #[derive(Clone, Debug)]
 pub struct Container {
@@ -25,23 +25,6 @@ impl From<&AuxillaryService> for Container {
             image: service.image.clone(),
             target_port: service.port,
             environment: service.environment.clone(),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct Registry {
-    pub base: Option<String>,
-    pub username: Option<String>,
-    pub password: Option<String>,
-}
-
-impl From<RegistryDetails> for Registry {
-    fn from(registry: RegistryDetails) -> Self {
-        Self {
-            base: registry.endpoint,
-            username: registry.username,
-            password: registry.password,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,6 @@ use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
-    pub registry: RegistryDetails,
     pub services: Vec<Service>,
     pub auxillary_services: Vec<AuxillaryService>,
 }
@@ -46,11 +45,4 @@ pub struct AuxillaryService {
     pub tag: String,
     pub port: u16,
     pub environment: Option<HashMap<String, String>>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct RegistryDetails {
-    pub endpoint: Option<String>,
-    pub username: Option<String>,
-    pub password: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 
 use crate::args::Args;
-use crate::common::{Container, Registry};
+use crate::common::Container;
 use crate::config::{AuxillaryService, Config, Service};
 use crate::docker::api::create_and_start_on_random_port;
 use crate::load_balancer::LoadBalancer;
@@ -31,13 +31,12 @@ async fn main() -> Result<()> {
 
     let args = Args::parse()?;
     let config = Config::from_file(args.get_config_path())?;
-    let registry = Registry::from(config.registry);
     let service_map = start_services(config.services).await?;
 
     // Start the auxillary services
     start_auxillary_services(config.auxillary_services).await?;
 
-    let mut load_balancer = LoadBalancer::new(registry, service_map);
+    let mut load_balancer = LoadBalancer::new(service_map);
     load_balancer.start_on_port(5000).await?;
 
     Ok(())


### PR DESCRIPTION
The registry concept will likely need to return in the future for basic authorisation support, but at the moment it makes a needless clutter of the configuration and related code.

This change:
* Removes all references to it
