### PR TITLE
feat: make auxillary services optional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     pub services: Vec<Service>,
-    pub auxillary_services: Vec<AuxillaryService>,
+    pub auxillary_services: Option<Vec<AuxillaryService>>,
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,9 @@ async fn main() -> Result<()> {
     let service_map = start_services(config.services).await?;
 
     // Start the auxillary services
-    start_auxillary_services(config.auxillary_services).await?;
+    if let Some(services) = config.auxillary_services {
+        start_auxillary_services(services).await?;
+    }
 
     let mut load_balancer = LoadBalancer::new(service_map);
     load_balancer.start_on_port(5000).await?;


### PR DESCRIPTION
Not all deployments will have auxillary services, so let's make them optional.

This change:
* Updates `auxillary_services` to use `Option<T>`
