### PR TITLE
deps: upgrade Rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68.0-alpine3.17 AS builder
+FROM rust:1.71.1-alpine3.18 AS builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
1.68 uses the old Git based index for dependencies, so this should make things a bit faster in CI.

This change:
* Updates to the latest base image for the builder
