### PR TITLE
feat: allow specifying ALB config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use crate::args::ConfigurationLocation;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
+    pub alb: AlbConfig,
     pub services: Vec<Service>,
     pub auxillary_services: Option<Vec<AuxillaryService>>,
 }
@@ -23,6 +24,12 @@ impl Config {
 
         Ok(config)
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+pub struct AlbConfig {
+    pub addr: String,
+    pub port: u16,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]

--- a/src/load_balancer/mod.rs
+++ b/src/load_balancer/mod.rs
@@ -35,8 +35,8 @@ impl LoadBalancer {
         }
     }
 
-    pub async fn start_on_port(&mut self, port: u16) -> Result<()> {
-        let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+    pub async fn start_on(&mut self, addr: Ipv4Addr, port: u16) -> Result<()> {
+        let addr = SocketAddrV4::new(addr, port);
         let listener = TcpListener::bind(addr)?;
 
         self.start(listener).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::str::FromStr;
 
 use color_eyre::eyre::Result;
 
@@ -35,6 +37,10 @@ async fn main() -> Result<()> {
 
     let args = Args::parse()?;
     let config = Config::from_location(&args.config_location).await?;
+
+    let addr = Ipv4Addr::from_str(&config.alb.addr)?;
+    let port = config.alb.port;
+
     let service_map = start_services(config.services).await?;
 
     // Start the auxillary services
@@ -43,7 +49,7 @@ async fn main() -> Result<()> {
     }
 
     let mut load_balancer = LoadBalancer::new(service_map);
-    load_balancer.start_on_port(5000).await?;
+    load_balancer.start_on(addr, port).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Currently the ALB defaults to being on `127.0.0.1` and port 5000, which doesn't work so well in a Docker context as it means we cannot expose the port properly.

This change:
* Adds configuration to enable custom values for these
