### PR TITLE
feat: get Docker working locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM rust:1.71.1-alpine3.18 AS builder
 
+RUN apk add --no-cache musl build-base clang llvm14
+RUN rustup target add x86_64-unknown-linux-musl
+
 WORKDIR /app
 COPY . .
 
-RUN apk add --no-cache musl build-base
-RUN rustup target add x86_64-unknown-linux-musl
+ENV CC_x86_64_unknown_linux_musl=clang
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"
 
 RUN cargo install --target x86_64-unknown-linux-musl --path .
 


### PR DESCRIPTION
Due to running on an M2 locally (and thus Apple Silicon), the standard Dockerfile doesn't seem to work and generally fails with linker errors around the `ring` library. Adding some extra environment variables works, so hopefully we can add these for CI as well and produce an image that works for both.

Additionally, we're reinstalling everything on every file change which isn't very good caching.

This change:
* Gets the Docker build working locally
* Moves the `apk` and `rustup` invocations earlier for better caching
