### PR TITLE
feat: use multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,30 @@
-FROM rust:1.71.1-alpine3.18 AS builder
-
-RUN apk add --no-cache musl build-base clang llvm14
-RUN rustup target add x86_64-unknown-linux-musl
+FROM lukemathwalker/cargo-chef:latest-rust-1.71.1-alpine3.18 AS chef
 
 WORKDIR /app
+
+# Plan the dependencies
+FROM chef AS planner
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+
+# Install anything we need for `musl` builds and set the environment variables
+RUN apk add --no-cache musl build-base clang llvm14
+RUN rustup target add x86_64-unknown-linux-musl
 
 ENV CC_x86_64_unknown_linux_musl=clang
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"
 
-RUN cargo install --target x86_64-unknown-linux-musl --path .
+# Build the dependencies themselves
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
 
+# Build the binary
+COPY . .
+RUN cargo build --release --target x86_64-unknown-linux-musl --bin f2
+
+# Copy over to the minimal image
 FROM gcr.io/distroless/static
-COPY --from=builder /usr/local/cargo/bin/f2 .
-ENTRYPOINT ["./f2"]
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/f2 /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/f2"]


### PR DESCRIPTION
`cargo-chef` is much more efficient than the previous approach for local builds, since it compiles all the dependencies separately to the final binary.

This means a rebuild in `--release` mode takes ~27s instead of the 3 minutes for a full build.

This change:
* Swaps to use this approach in general
