### PR TITLE
fix: update entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ RUN cargo build --release --target x86_64-unknown-linux-musl --bin f2
 
 # Copy over to the minimal image
 FROM gcr.io/distroless/static
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/f2 /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/f2"]
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/f2 .
+ENTRYPOINT ["./f2"]


### PR DESCRIPTION
This logic is incorrect, as it copies the binary somewhere that doesn't exist and then tries to run that. This causes the container to fail immediately.

This change:
* Copies it to the current directory, then runs that
