### PR TITLE
feat: allow proxying in Docker

### DIFF
--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
 
 use serde::{Deserialize, Serialize};
 
@@ -47,5 +48,7 @@ pub struct InspectContainerResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct NetworkSettings {
+    #[serde(rename = "IPAddress")]
+    pub ip_address: Ipv4Addr,
     pub ports: HashMap<String, Option<Vec<PortBinding>>>,
 }

--- a/src/load_balancer/mod.rs
+++ b/src/load_balancer/mod.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 
 use crate::config::Service;
 
-type ServiceMap = HashMap<Service, Vec<u16>>;
+type ServiceMap = HashMap<Service, Vec<SocketAddrV4>>;
 
 mod proxy;
 

--- a/src/load_balancer/proxy.rs
+++ b/src/load_balancer/proxy.rs
@@ -1,4 +1,4 @@
-use std::net::{Ipv4Addr, SocketAddrV4};
+use std::net::SocketAddrV4;
 use std::sync::Arc;
 
 use color_eyre::eyre::{ContextCompat, Result};
@@ -50,7 +50,7 @@ pub async fn handle_request(
             .context("Failed to select downstream host")?
     };
 
-    let downstream_addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, downstream);
+    let downstream_addr = SocketAddrV4::new(*downstream.ip(), downstream.port());
     let path_and_query = uri.path_and_query().map_or("/", PathAndQuery::as_str);
 
     tracing::info!(%downstream_addr, %path_and_query, "Proxing request to a downstream server");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddrV4};
 use std::str::FromStr;
 
 use color_eyre::eyre::Result;
@@ -54,8 +54,8 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn start_services(services: Vec<Service>) -> Result<HashMap<Service, Vec<u16>>> {
-    let mut service_map: HashMap<Service, Vec<u16>> = HashMap::new();
+async fn start_services(services: Vec<Service>) -> Result<HashMap<Service, Vec<SocketAddrV4>>> {
+    let mut service_map: HashMap<Service, Vec<SocketAddrV4>> = HashMap::new();
 
     for service in services {
         let tag = &service.tag;
@@ -63,8 +63,8 @@ async fn start_services(services: Vec<Service>) -> Result<HashMap<Service, Vec<u
         let mut ports = Vec::new();
 
         for _ in 0..service.replicas {
-            let port = create_and_start_on_random_port(&container, tag).await?;
-            ports.push(port);
+            let addr = create_and_start_on_random_port(&container, tag).await?;
+            ports.push(SocketAddrV4::new(*addr.ip(), container.target_port));
         }
 
         service_map.insert(service, ports);


### PR DESCRIPTION
`f2` doesn't currently work it is running inside Docker itself, since it tries to proxy everything to `localhost` and the port binding that's exposed to the local machine.

However, we'll be on the same Docker network as the running containers we want to proxy to and they'll be exposing a port (that we then expose on a random port to the local machine). Thus, all we need to do is grab those IP addresses and make requests to them instead.

We already get some of the network details, so this is an easy addition to that request.

This change:
* Grabs the IP address of the running containers
* Proxies requests to those instead
* Ignores the exposed ports for now, these can probably be tidied up in future or `f2` can run in Docker/non-Docker modes
* Updates the tests to use `LOCALHOST` as we now deal in `SocketAddrV4` a lot more
