### PR TITLE
refactor: stop searching for bound ports

### DIFF
--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -1,9 +1,6 @@
-use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use serde::{Deserialize, Serialize};
-
-type EmptyMap = HashMap<(), ()>;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -15,22 +12,7 @@ pub struct ImageSummary {
 #[serde(rename_all = "PascalCase")]
 pub struct CreateContainerOptions {
     pub image: String,
-    pub exposed_ports: HashMap<String, EmptyMap>,
-    pub host_config: HostConfig,
     pub env: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct HostConfig {
-    pub port_bindings: HashMap<String, Vec<PortBinding>>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct PortBinding {
-    pub host_ip: Option<String>,
-    pub host_port: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -50,5 +32,4 @@ pub struct InspectContainerResponse {
 pub struct NetworkSettings {
     #[serde(rename = "IPAddress")]
     pub ip_address: Ipv4Addr,
-    pub ports: HashMap<String, Option<Vec<PortBinding>>>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use color_eyre::eyre::Result;
 use crate::args::Args;
 use crate::common::Container;
 use crate::config::{AuxillaryService, Config, Service};
-use crate::docker::api::create_and_start_on_random_port;
+use crate::docker::api::create_and_start_container;
 use crate::load_balancer::LoadBalancer;
 
 mod args;
@@ -63,8 +63,8 @@ async fn start_services(services: Vec<Service>) -> Result<HashMap<Service, Vec<S
         let mut ports = Vec::new();
 
         for _ in 0..service.replicas {
-            let addr = create_and_start_on_random_port(&container, tag).await?;
-            ports.push(SocketAddrV4::new(*addr.ip(), container.target_port));
+            let addr = create_and_start_container(&container, tag).await?;
+            ports.push(SocketAddrV4::new(addr, container.target_port));
         }
 
         service_map.insert(service, ports);
@@ -77,7 +77,7 @@ async fn start_auxillary_services(services: Vec<AuxillaryService>) -> Result<()>
     for service in services {
         let tag = &service.tag;
         let container = Container::from(&service);
-        let port = create_and_start_on_random_port(&container, tag).await?;
+        let port = create_and_start_container(&container, tag).await?;
 
         tracing::info!("Started {} on port {port}", service.image);
     }


### PR DESCRIPTION
Now that everything is in the same Docker network, we don't actually need to expose any ports to the host machine. Docker will always give us a unique IP address for the container (until we run out) and thus we can just use this along with the host port defined in the YAML.

This removes a lot of the odd complexity around exposing ports initially and then trying to retrieve them.

This change:
* Removes the functionality, assuming we will always be running `f2` inside Docker itself
