### PR TITLE
feat: add secret resolution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Dockerfile
 
 *.sh
 *.yaml
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 f2.yaml
 
 *.sh
+*.key
+.env
+Justfile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +492,12 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -561,6 +573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +632,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -658,6 +688,7 @@ version = "0.1.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
+ "base64",
  "chrono",
  "color-eyre",
  "futures",
@@ -665,6 +696,7 @@ dependencies = [
  "hyperlocal",
  "pico-args",
  "rand",
+ "rsa",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1028,12 +1060,21 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "log"
@@ -1096,6 +1137,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,12 +1164,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1164,6 +1234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1285,27 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1318,6 +1418,28 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
+dependencies = [
+ "byteorder",
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1508,6 +1630,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,6 +1669,16 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 aws-config = "0.56.0"
 aws-sdk-s3 = "0.29.0"
+base64 = "0.21.2"
 chrono = "0.4.24"
 color-eyre = "0.6.2"
 futures = "0.3.28"
@@ -15,6 +16,7 @@ hyper = { version = "0.14.25", features = ["client", "server", "tcp", "http1"] }
 hyperlocal = "0.8.0"
 pico-args = "0.5.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
+rsa = "0.9.2"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 serde_yaml = "0.9.21"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,12 +1,21 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 use crate::config::{AuxillaryService, Service};
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Container {
     pub image: String,
     pub target_port: u16,
     pub environment: Option<HashMap<String, String>>,
+}
+
+impl fmt::Debug for Container {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Container")
+            .field("image", &self.image)
+            .field("target_port", &self.target_port)
+            .finish()
+    }
 }
 
 impl From<&Service> for Container {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,34 @@
+use std::env;
+
+use base64::alphabet::STANDARD;
+use base64::engine::{GeneralPurpose, GeneralPurposeConfig};
+use base64::Engine;
+use color_eyre::Result;
+use rsa::pkcs8::DecodePrivateKey;
+use rsa::{Pkcs1v15Encrypt, RsaPrivateKey};
+
+pub fn get_private_key(environment_variable: &str) -> Result<RsaPrivateKey> {
+    let base64 = env::var(environment_variable)?;
+    let decoded = base64_decode(&base64)?;
+    let utf8 = String::from_utf8(decoded)?;
+    let parsed = RsaPrivateKey::from_pkcs8_pem(&utf8)?;
+
+    parsed.validate()?;
+
+    Ok(parsed)
+}
+
+pub fn decrypt(secret: &str, key: &RsaPrivateKey) -> Result<String> {
+    let decoded = base64_decode(secret)?;
+    let decrypted = key.decrypt(Pkcs1v15Encrypt, &decoded)?;
+    let decoded = String::from_utf8(decrypted)?;
+
+    Ok(decoded)
+}
+
+fn base64_decode(value: &str) -> Result<Vec<u8>> {
+    let engine = GeneralPurpose::new(&STANDARD, GeneralPurposeConfig::new());
+    let decoded = engine.decode(value)?;
+
+    Ok(decoded)
+}

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -81,7 +81,7 @@ impl Client {
             env,
         };
 
-        tracing::info!(?options, "Creating a container");
+        tracing::info!(%image, "Creating a container");
 
         let body = serde_json::to_vec(&options)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crate::load_balancer::LoadBalancer;
 mod args;
 mod common;
 mod config;
+mod crypto;
 mod docker;
 mod load_balancer;
 
@@ -36,7 +37,10 @@ async fn main() -> Result<()> {
     setup()?;
 
     let args = Args::parse()?;
-    let config = Config::from_location(&args.config_location).await?;
+    let mut config = Config::from_location(&args.config_location).await?;
+
+    let private_key = crypto::get_private_key("ENV_PRIVATE_KEY")?;
+    config.resolve_secrets(&private_key)?;
 
     let addr = Ipv4Addr::from_str(&config.alb.addr)?;
     let port = config.alb.port;


### PR DESCRIPTION
In order to store values such as the database URL or JWT signing key in configuration, we'll want to encrypt them somehow first. `f2` can then decrypt them on startup and provide them to services when they start up.

This change:
* Adds support for an RSA private key used to decrypt the secrets
* Avoids logging them on container creation as they are plaintext
