### PR TITLE
refactor: add `ContainerId` newtype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "futures",
+ "hex",
  "hyper",
  "hyperlocal",
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ serde_yaml = "0.9.21"
 tokio = { version = "1.27.0", features = ["macros", "rt-multi-thread", "time", "fs"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+
+[dev-dependencies]
+hex = "0.4.3"

--- a/src/docker/api.rs
+++ b/src/docker/api.rs
@@ -4,10 +4,11 @@ use color_eyre::eyre::Result;
 
 use crate::common::Container;
 use crate::docker::client::Client;
+use crate::docker::models::ContainerId;
 
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub struct StartedContainerDetails {
-    pub id: String,
+    pub id: ContainerId,
     pub addr: Ipv4Addr,
 }
 

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -10,6 +10,8 @@ use crate::docker::models::{
     NetworkSettings,
 };
 
+use super::models::ContainerId;
+
 pub struct Client {
     client: hyper::Client<UnixConnector, Body>,
     base: String,
@@ -71,7 +73,7 @@ impl Client {
         &self,
         image: &str,
         environment: &Option<HashMap<String, String>>,
-    ) -> Result<String> {
+    ) -> Result<ContainerId> {
         let uri = self.build_uri("/containers/create");
 
         let env = format_environment_variables(environment);
@@ -100,7 +102,7 @@ impl Client {
         Ok(body.id)
     }
 
-    pub async fn start_container(&self, id: &str) -> Result<()> {
+    pub async fn start_container(&self, id: &ContainerId) -> Result<()> {
         let path = format!("/containers/{id}/start");
         let uri = self.build_uri(&path);
 
@@ -116,7 +118,7 @@ impl Client {
         Ok(())
     }
 
-    pub async fn get_container_ip(&self, id: &str) -> Result<Ipv4Addr> {
+    pub async fn get_container_ip(&self, id: &ContainerId) -> Result<Ipv4Addr> {
         let path = format!("/containers/{id}/json");
         let uri = self.build_uri(&path);
 

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,4 +1,4 @@
 pub mod api;
+pub mod models;
 
 mod client;
-mod models;

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -1,6 +1,16 @@
+use std::fmt;
 use std::net::Ipv4Addr;
 
 use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
+pub struct ContainerId(pub String);
+
+impl fmt::Display for ContainerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -18,7 +28,7 @@ pub struct CreateContainerOptions {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateContainerResponse {
-    pub id: String,
+    pub id: ContainerId,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/load_balancer/tests.rs
+++ b/src/load_balancer/tests.rs
@@ -11,6 +11,7 @@ use hyper::{Body, Client, Request, Response, Server, StatusCode};
 use crate::args::ConfigurationLocation;
 use crate::config::{AlbConfig, Config, Service};
 use crate::docker::api::StartedContainerDetails;
+use crate::docker::models::ContainerId;
 use crate::load_balancer::LoadBalancer;
 use crate::reconciler::Reconciler;
 use crate::service_registry::ServiceRegistry;
@@ -33,7 +34,7 @@ fn create_service<T: Into<Option<&'static str>>>(
 
 fn add_container(service_registry: &mut ServiceRegistry, name: &str) {
     let details = StartedContainerDetails {
-        id: String::from("6cd915f16ab3"),
+        id: ContainerId(String::from("6cd915f16ab3")),
         addr: Ipv4Addr::LOCALHOST,
     };
 


### PR DESCRIPTION
We're currently just passing around the container identifiers as raw strings, which is not a very Rust-like pattern. It also makes them a little more annoying to use in tests.

This change:
* Adds a `ContainerId` wrapper around a `String`
* Adds a method to generate a random one for tests
* Updates all the usages to work with it
