### PR TITLE
fix: force HTTP 1.1

### DIFF
--- a/src/load_balancer/mod.rs
+++ b/src/load_balancer/mod.rs
@@ -80,7 +80,7 @@ impl LoadBalancer {
             let incoming = AddrIncoming::from_listener(listener)?;
             let acceptor = TlsAcceptor::builder()
                 .with_single_cert(certs, key)?
-                .with_all_versions_alpn()
+                .with_http11_alpn()
                 .with_incoming(incoming);
 
             let service = make_service_fn(move |_| {


### PR DESCRIPTION
Unfortunately the load balancer doesn't seem to work property with HTTP 2 at the moment. For now, let's just allow HTTP 1.1.

This change:
* Swaps to only allow HTTP 1.1 on the TLS acceptor
