### PR TITLE
feat: support remote private keys

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use base64::alphabet::STANDARD;
 use base64::engine::{GeneralPurpose, GeneralPurposeConfig};
 use base64::Engine;
@@ -7,11 +5,9 @@ use color_eyre::Result;
 use rsa::pkcs8::DecodePrivateKey;
 use rsa::{Pkcs1v15Encrypt, RsaPrivateKey};
 
-pub fn get_private_key(environment_variable: &str) -> Result<RsaPrivateKey> {
-    let base64 = env::var(environment_variable)?;
-    let decoded = base64_decode(&base64)?;
-    let utf8 = String::from_utf8(decoded)?;
-    let parsed = RsaPrivateKey::from_pkcs8_pem(&utf8)?;
+pub fn parse_private_key(bytes: &[u8]) -> Result<RsaPrivateKey> {
+    let utf8 = std::str::from_utf8(bytes)?;
+    let parsed = RsaPrivateKey::from_pkcs8_pem(utf8)?;
 
     parsed.validate()?;
 

--- a/src/load_balancer/tests.rs
+++ b/src/load_balancer/tests.rs
@@ -99,6 +99,7 @@ async fn spawn_load_balancer(service_registry: ServiceRegistry) -> Result<Socket
                         reconciliation: String::from("/reconciliation"),
                         tls: None,
                     },
+                    secrets: None,
                     services: HashMap::new(),
                     auxillary_services: None,
                 },


### PR DESCRIPTION
Currently the private key needs to be passed as an environment variable on startup, which is somewhat annoying. Every time a new instance is set up it much be downloaded from 1Password and re-encoded.

Ideally, the instance could just pull the key from a remote location on startup and then decrypt the secrets.

This change:
* Adds support for remote private keys
* Makes private keys optional, as they're not always required
