### PR TITLE
feat: support all service alterations

### DIFF
--- a/src/service_registry.rs
+++ b/src/service_registry.rs
@@ -36,12 +36,6 @@ impl ServiceRegistry {
         self.definitions.remove(service);
     }
 
-    pub fn update_tag(&mut self, service: &str, tag: &str) {
-        if let Some(definition) = self.definitions.get_mut(service) {
-            definition.tag = tag.into();
-        }
-    }
-
     pub fn get_running_containers(
         &self,
         service: &str,
@@ -156,23 +150,6 @@ mod tests {
         registry.undefine(service);
 
         assert!(registry.get_definition(service).is_none());
-    }
-
-    #[test]
-    fn can_update_tag_for_definitions() {
-        let mut registry = ServiceRegistry::new();
-        let service = "backend";
-        let definition = some_service();
-
-        registry.define(service, definition);
-
-        let new_tag = "foobar";
-        registry.update_tag(service, new_tag);
-
-        assert_eq!(
-            registry.get_definition(service).map(|def| def.tag.as_str()),
-            Some(new_tag)
-        );
     }
 
     #[test]


### PR DESCRIPTION
Sometimes, a container may have its tag bumped as well as some new configuration being added. This causes issues as `f2` will use the old environment variables for the new image and thus it may fail to start (which is not handled very gracefully at the moment).

Instead of listening only for tag updates, we can just check for any changes to the service entirely. This means changes to the port, tag, replicas and environment will all cause a roll.

`clippy` also didn't like everything starting with the same prefix, so this renames the variants too.

This change:
* Adds the new `Alteration` variant and removes `TagUpdate`
* Handles the new variant in the reconciler
* Updates the tests to handle it
