### PR TITLE
fix: decrypt only on container creation

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,12 +1,66 @@
 use std::{collections::HashMap, fmt};
 
+use color_eyre::eyre::{eyre, Result, WrapErr};
+use rsa::RsaPrivateKey;
+
 use crate::config::{AuxillaryService, Service};
+use crate::crypto::decrypt;
+
+#[derive(Clone)]
+pub struct EncryptedEnvironment {
+    variables: HashMap<String, String>,
+}
+
+impl EncryptedEnvironment {
+    pub fn decrypt(&self, private_key: Option<&RsaPrivateKey>) -> Result<Environment> {
+        let mut variables = HashMap::new();
+
+        for (key, value) in self.variables.clone().into_iter() {
+            tracing::info!("Resolving secret for {key}");
+
+            let value = match value.strip_prefix("secret:") {
+                Some(value) => {
+                    let private_key = private_key
+                        .ok_or_else(|| eyre!("Tried to decrypt secret without a key"))?;
+
+                    decrypt(value, private_key)
+                        .wrap_err_with(|| format!("Failed to decrypt secret value for '{key}'"))?
+                }
+                None => value,
+            };
+
+            variables.insert(key, value);
+        }
+
+        Ok(Environment { variables })
+    }
+}
+
+#[derive(Clone)]
+pub struct Environment {
+    pub variables: HashMap<String, String>,
+}
 
 #[derive(Clone)]
 pub struct Container {
     pub image: String,
     pub target_port: u16,
-    pub environment: Option<HashMap<String, String>>,
+    pub environment: Option<EncryptedEnvironment>,
+}
+
+impl Container {
+    pub fn decrypt_environment(
+        &self,
+        private_key: Option<&RsaPrivateKey>,
+    ) -> Result<Option<Environment>> {
+        let Some(ref environment) = self.environment else {
+            return Ok(None);
+        };
+
+        let decrypted = environment.decrypt(private_key)?;
+
+        Ok(Some(decrypted))
+    }
 }
 
 impl fmt::Debug for Container {
@@ -20,20 +74,140 @@ impl fmt::Debug for Container {
 
 impl From<&Service> for Container {
     fn from(service: &Service) -> Self {
+        let environment = service
+            .environment
+            .clone()
+            .map(|variables| EncryptedEnvironment { variables });
+
         Self {
             image: service.image.clone(),
             target_port: service.port,
-            environment: service.environment.clone(),
+            environment,
         }
     }
 }
 
 impl From<&AuxillaryService> for Container {
     fn from(service: &AuxillaryService) -> Self {
+        let environment = service
+            .environment
+            .clone()
+            .map(|variables| EncryptedEnvironment { variables });
+
         Self {
             image: service.image.clone(),
             target_port: service.port,
-            environment: service.environment.clone(),
+            environment,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use color_eyre::eyre::{eyre, Result};
+    use rsa::{Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
+
+    use super::EncryptedEnvironment;
+
+    fn generate_keys() -> Result<(RsaPublicKey, RsaPrivateKey)> {
+        let mut rng = rand::thread_rng();
+        let bits = 256;
+
+        let private_key = RsaPrivateKey::new(&mut rng, bits)?;
+        let public_key = RsaPublicKey::from(&private_key);
+
+        Ok((public_key, private_key))
+    }
+
+    fn encrypt_and_encode_value(value: &str, public_key: &RsaPublicKey) -> Result<String> {
+        use base64::{engine::general_purpose, Engine as _};
+
+        let mut rng = rand::thread_rng();
+
+        let encrypted = public_key.encrypt(&mut rng, Pkcs1v15Encrypt, value.as_bytes())?;
+
+        Ok(general_purpose::STANDARD.encode(encrypted))
+    }
+
+    #[test]
+    fn environments_can_be_decrypted() -> Result<()> {
+        let (public, private) = generate_keys()?;
+
+        let plaintext = "foobar";
+        let encoded = encrypt_and_encode_value(plaintext, &public)?;
+
+        let mut variables = HashMap::new();
+        variables.insert(String::from("key"), format!("secret:{encoded}"));
+
+        let encrypted_environment = EncryptedEnvironment { variables };
+
+        let decrypted = encrypted_environment.decrypt(Some(&private))?;
+        let value = decrypted
+            .variables
+            .get("key")
+            .ok_or_else(|| eyre!("Failed to get a value for the key"))?;
+
+        assert_eq!(value, plaintext);
+
+        Ok(())
+    }
+
+    #[test]
+    fn unencrypted_keys_are_left_alone() -> Result<()> {
+        let mut variables = HashMap::new();
+        variables.insert(String::from("key"), String::from("value"));
+
+        let encrypted_environment = EncryptedEnvironment { variables };
+
+        let decrypted = encrypted_environment.decrypt(None)?;
+        let value = decrypted
+            .variables
+            .get("key")
+            .ok_or_else(|| eyre!("Failed to get a value for the key"))?;
+
+        assert_eq!(value, "value");
+
+        Ok(())
+    }
+
+    #[test]
+    fn decryption_errors_if_secrets_exist_without_private_key() -> Result<()> {
+        let (public, _) = generate_keys()?;
+
+        let plaintext = "foobar";
+        let encoded = encrypt_and_encode_value(plaintext, &public)?;
+
+        let mut variables = HashMap::new();
+        variables.insert(String::from("key"), format!("secret:{encoded}"));
+
+        let encrypted_environment = EncryptedEnvironment { variables };
+
+        let decrypted = encrypted_environment.decrypt(None);
+
+        assert!(decrypted.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn decryption_failures_return_an_error() -> Result<()> {
+        let (public, _) = generate_keys()?;
+        let (_, unrelated_private) = generate_keys()?;
+
+        let plaintext = "foobar";
+        let encoded = encrypt_and_encode_value(plaintext, &public)?;
+
+        let mut variables = HashMap::new();
+        variables.insert(String::from("key"), format!("secret:{encoded}"));
+
+        let encrypted_environment = EncryptedEnvironment { variables };
+
+        let decrypted = encrypted_environment.decrypt(Some(&unrelated_private));
+
+        assert!(decrypted.is_err());
+
+        Ok(())
     }
 }

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use color_eyre::eyre::{self, Result};
 use hyper::{Body, Method, Request, Uri};
 use hyperlocal::{UnixClientExt, UnixConnector};
 
+use crate::common::Environment;
 use crate::docker::models::{
     CreateContainerOptions, CreateContainerResponse, ImageSummary, InspectContainerResponse,
     NetworkSettings,
@@ -72,7 +72,7 @@ impl Client {
     pub async fn create_container(
         &self,
         image: &str,
-        environment: &Option<HashMap<String, String>>,
+        environment: &Option<Environment>,
     ) -> Result<ContainerId> {
         let uri = self.build_uri("/containers/create");
 
@@ -155,12 +155,13 @@ impl Client {
     }
 }
 
-fn format_environment_variables(environment: &Option<HashMap<String, String>>) -> Vec<String> {
+fn format_environment_variables(environment: &Option<Environment>) -> Vec<String> {
     let Some(environment) = environment else {
         return Vec::new();
     };
 
     environment
+        .variables
         .iter()
         .map(|(k, v)| format!("{k}={v}"))
         .collect()


### PR DESCRIPTION
As described in #35, the reconciliation doesn't handle secrets very well since it will compare the locally decrypted ones to the encrypted ones in the file and decide that they have changed. It will then start services with the encrypted values which can cause failures.

Instead, we should keep them decrypted until we need them. This allows the containers to always get decrypted secrets, but we always compare against the encrypted versions (which is better for key changes as well).

This change:
* Adds the ability to fetch the private key to the configuration so it can be used in a few places
* Updates the container creation to take a private key and do the decryption
* Adds some tests to make sure the decryption behaves properly
