### PR TITLE
fix: stop decrypting on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,16 +44,15 @@ async fn main() -> Result<()> {
     setup()?;
 
     let args = Args::parse()?;
-    let mut config = Config::from_location(&args.config_location).await?;
-
-    let private_key = config.get_private_key().await?;
-    config.resolve_secrets(private_key.as_ref())?;
+    let config = Config::from_location(&args.config_location).await?;
 
     let addr = Ipv4Addr::from_str(&config.alb.addr)?;
     let port = config.alb.port;
     let tls = config.alb.tls.clone();
 
     let mut service_registry = ServiceRegistry::new();
+    let private_key = config.get_private_key().await?;
+
     start_services(
         &config.services,
         &mut service_registry,

--- a/src/reconciler.rs
+++ b/src/reconciler.rs
@@ -55,6 +55,8 @@ impl Reconciler {
     }
 
     async fn handle_diff(&self, diff: Diff) -> Result<()> {
+        tracing::info!("Handling a diff: {diff:?}");
+
         match diff {
             Diff::Alteration {
                 name,


### PR DESCRIPTION
We're still decrypting the secrets in-place on startup, which means that when we reconcile for the first time anything with secrets will be restarted. This isn't the end of the world as they are correctly started with the right values both times, but it's a little pointless.

This change:
* Stops decrypting on startup
* Removes some dead code
