### PR TITLE
refactor: remove unnecessary `collect`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyperlocal",
+ "indexmap 2.1.0",
  "pico-args",
  "rand",
  "rsa",
@@ -873,9 +874,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "hermit-abi"
@@ -1036,12 +1037,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -1595,7 +1596,7 @@ version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3.28"
 hyper = { version = "0.14.25", features = ["client", "server", "tcp", "http1"] }
 hyper-rustls = "0.24.1"
 hyperlocal = "0.8.0"
+indexmap = "2.1.0"
 pico-args = "0.5.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rsa = "0.9.2"

--- a/src/reconciler.rs
+++ b/src/reconciler.rs
@@ -1,7 +1,7 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use color_eyre::Result;
+use indexmap::IndexSet;
 use tokio::sync::RwLock;
 
 use crate::args::ConfigurationLocation;
@@ -65,7 +65,7 @@ impl Reconciler {
                 let read_lock = self.registry.read().await;
                 let definition = read_lock.get_definition(&name).unwrap();
                 let replicas = definition.replicas;
-                let running_containers: HashSet<_> =
+                let running_containers: IndexSet<_> =
                     read_lock.get_running_containers(&name).unwrap().clone();
 
                 let container = Container::from(&new_definition);

--- a/src/service_registry.rs
+++ b/src/service_registry.rs
@@ -1,4 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+
+use indexmap::IndexSet;
 
 use crate::config::Service;
 use crate::docker::api::StartedContainerDetails;
@@ -16,7 +18,7 @@ fn compute_path_prefix_match(path: &str, prefix: Option<&str>) -> usize {
 #[derive(Debug, Default)]
 pub struct ServiceRegistry {
     definitions: HashMap<String, Service>,
-    containers: HashMap<String, HashSet<StartedContainerDetails>>,
+    containers: HashMap<String, IndexSet<StartedContainerDetails>>,
 }
 
 impl ServiceRegistry {
@@ -39,7 +41,7 @@ impl ServiceRegistry {
     pub fn get_running_containers(
         &self,
         service: &str,
-    ) -> Option<&HashSet<StartedContainerDetails>> {
+    ) -> Option<&IndexSet<StartedContainerDetails>> {
         tracing::debug!("Fetching running containers for {service}");
 
         self.containers.get(service)
@@ -70,7 +72,7 @@ impl ServiceRegistry {
         &self,
         host: &str,
         path: &str,
-    ) -> Option<(&HashSet<StartedContainerDetails>, u16)> {
+    ) -> Option<(&IndexSet<StartedContainerDetails>, u16)> {
         self.definitions
             .iter()
             .filter(|entry| entry.1.host == host)


### PR DESCRIPTION
Since the service registry stores a `HashSet` of downstream addresses, we can't easily pick a random one to go to when proxying requests. This means we need to `collect` into a `Vec` before choosing, which is a little annoying.

`indexmap` provides an `IndexSet` type which has the best of both worlds, we simulataneously cannot have duplicates but also can easily select a random index.

This change:
* Adds a dependency on `indexmap`
* Updates the service registry to use `IndexSet` over `HashSet`
* Fixes the selection methodology
