### PR TITLE
refactor: swap for proper type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
+use std::net::Ipv4Addr;
 use std::path::PathBuf;
 
 use color_eyre::eyre::{Context, Result};
@@ -96,7 +97,7 @@ impl Config {
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
 pub struct AlbConfig {
-    pub addr: String,
+    pub addr: Ipv4Addr,
     pub port: u16,
     pub reconciliation: String,
     pub tls: Option<TlsConfig>,
@@ -183,6 +184,7 @@ pub struct AuxillaryService {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::net::Ipv4Addr;
 
     use crate::config::{AlbConfig, Config, Diff, Service};
 
@@ -203,7 +205,7 @@ mod tests {
 
         Config {
             alb: AlbConfig {
-                addr: String::new(),
+                addr: Ipv4Addr::LOCALHOST,
                 port: 5000,
                 reconciliation: String::new(),
                 tls: None,

--- a/src/load_balancer/tests.rs
+++ b/src/load_balancer/tests.rs
@@ -94,7 +94,7 @@ async fn spawn_load_balancer(service_registry: ServiceRegistry) -> Result<Socket
                 ConfigurationLocation::Filesystem(PathBuf::new()),
                 Config {
                     alb: AlbConfig {
-                        addr: String::from("127.0.0.1"),
+                        addr: Ipv4Addr::LOCALHOST,
                         port: 5000,
                         reconciliation: String::from("/reconciliation"),
                         tls: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use color_eyre::eyre::Result;
@@ -46,7 +44,7 @@ async fn main() -> Result<()> {
     let args = Args::parse()?;
     let config = Config::from_location(&args.config_location).await?;
 
-    let addr = Ipv4Addr::from_str(&config.alb.addr)?;
+    let addr = config.alb.addr;
     let port = config.alb.port;
     let tls = config.alb.tls.clone();
 


### PR DESCRIPTION
For some reason, we're reading the `addr` as a `String` and then converting to an `Ipv4Addr` later on. The latter already implements `Deserialize` so there's no real point in doing this.

This change:
* Swaps to use `Ipv4Addr`
