### PR TITLE
refactor: abstract Docker away

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 /target
 Dockerfile
+Justfile
 
 *.sh
 *.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +697,7 @@ dependencies = [
 name = "f2"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "base64",
@@ -1320,18 +1332,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1693,9 +1705,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.79"
 aws-config = "0.56.0"
 aws-sdk-s3 = "0.29.0"
 base64 = "0.21.2"

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -12,7 +12,20 @@ impl fmt::Display for ContainerId {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[cfg(test)]
+impl ContainerId {
+    pub fn random() -> Self {
+        use rand::RngCore;
+
+        let mut rng = rand::rngs::ThreadRng::default();
+        let mut buf: [u8; 6] = [0; 6];
+        rng.fill_bytes(buf.as_mut_slice());
+
+        Self(hex::encode(buf))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct ImageSummary {
     pub repo_tags: Vec<String>,

--- a/src/load_balancer/mod.rs
+++ b/src/load_balancer/mod.rs
@@ -14,25 +14,26 @@ use rustls::sign::{any_supported_type, CertifiedKey};
 use tokio::sync::{Mutex, RwLock};
 
 use crate::config::TlsConfig;
+use crate::docker::client::DockerClient;
 use crate::reconciler::Reconciler;
 use crate::service_registry::ServiceRegistry;
 
 mod proxy;
 
 #[derive(Debug)]
-pub struct LoadBalancer {
+pub struct LoadBalancer<C: DockerClient> {
     service_registry: Arc<RwLock<ServiceRegistry>>,
     client: Client<HttpConnector>,
     rng: Arc<Mutex<SmallRng>>,
     reconciler_path: Arc<str>,
-    reconciler: Arc<Reconciler>,
+    reconciler: Arc<Reconciler<C>>,
 }
 
-impl LoadBalancer {
+impl<C: DockerClient + Sync + Send + 'static> LoadBalancer<C> {
     pub fn new(
         service_registry: Arc<RwLock<ServiceRegistry>>,
         reconciler_path: &str,
-        reconciler: Reconciler,
+        reconciler: Reconciler<C>,
     ) -> Self {
         let client = Client::new();
         let rng = Arc::new(Mutex::new(SmallRng::from_entropy()));

--- a/src/load_balancer/proxy.rs
+++ b/src/load_balancer/proxy.rs
@@ -9,15 +9,16 @@ use rand::prelude::SmallRng;
 use rand::RngCore;
 use tokio::sync::{Mutex, RwLock};
 
+use crate::docker::client::DockerClient;
 use crate::reconciler::Reconciler;
 use crate::service_registry::ServiceRegistry;
 
-pub async fn handle_request(
+pub async fn handle_request<C: DockerClient>(
     service_registry: Arc<RwLock<ServiceRegistry>>,
     rng: Arc<Mutex<SmallRng>>,
     client: Client<HttpConnector>,
     reconciliation_path: Arc<str>,
-    reconciler: Arc<Reconciler>,
+    reconciler: Arc<Reconciler<C>>,
     mut req: Request<Body>,
 ) -> Result<Response<Body>> {
     let uri = req.uri();

--- a/src/load_balancer/tests.rs
+++ b/src/load_balancer/tests.rs
@@ -15,6 +15,7 @@ use crate::config::{AlbConfig, Config, Service};
 use crate::docker::api::StartedContainerDetails;
 use crate::docker::models::ContainerId;
 use crate::load_balancer::LoadBalancer;
+use crate::reconciler::tests::FakeDockerClient;
 use crate::reconciler::Reconciler;
 use crate::service_registry::ServiceRegistry;
 
@@ -103,6 +104,7 @@ async fn spawn_load_balancer(service_registry: ServiceRegistry) -> Result<Socket
                     services: HashMap::new(),
                     auxillary_services: None,
                 },
+                FakeDockerClient::default(),
             ),
         );
 

--- a/src/service_registry.rs
+++ b/src/service_registry.rs
@@ -89,21 +89,10 @@ mod tests {
     use std::collections::HashSet;
     use std::net::Ipv4Addr;
 
-    use rand::rngs::ThreadRng;
-    use rand::RngCore;
-
     use crate::config::Service;
     use crate::docker::api::StartedContainerDetails;
     use crate::docker::models::ContainerId;
     use crate::service_registry::ServiceRegistry;
-
-    fn random_container_id() -> ContainerId {
-        let mut rng = ThreadRng::default();
-        let mut buf: [u8; 6] = [0; 6];
-        rng.fill_bytes(buf.as_mut_slice());
-
-        ContainerId(hex::encode(buf))
-    }
 
     fn some_service() -> Service {
         Service {
@@ -158,8 +147,8 @@ mod tests {
     fn can_store_and_fetch_container_data() {
         let mut registry = ServiceRegistry::new();
 
-        let container1 = random_container_id();
-        let container2 = random_container_id();
+        let container1 = ContainerId::random();
+        let container2 = ContainerId::random();
 
         let first = StartedContainerDetails {
             id: container1.clone(),
@@ -211,7 +200,7 @@ mod tests {
     }
 
     fn add_container(registry: &mut ServiceRegistry, name: &str) -> ContainerId {
-        let id = random_container_id();
+        let id = ContainerId::random();
 
         let details = StartedContainerDetails {
             id: id.clone(),


### PR DESCRIPTION
The Docker functionality gets in the way of testing fairly frequently, since this is a container orchestrator. This means the reconciler is difficult to write tests for as it interacts heavily with creating new containers or removing existing ones.

Instead of this, we can work towards using a `DockerClient` trait. This allows us to use a fake implementation in test code that just stores a bit of state and acts as if it has talked to the Docker API. Production code can still talk to Docker normally.

This also has the nice benefit of reducing the number of places we instantiate a Docker client (to just the one).

This change:
* Introduces the trait, regular and fake implementations
* Adds a test to the reconcilier to do some sanity checks
