### PR TITLE
refactor: separate certificate handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "async-trait"
 version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +783,7 @@ dependencies = [
 name = "f2"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arc-swap = "1.7.1"
 async-trait = "0.1.79"
 aws-config = "1.1.9"
 aws-sdk-s3 = "1.21.0"

--- a/src/load_balancer/mod.rs
+++ b/src/load_balancer/mod.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddrV4, TcpListener};
 use std::sync::Arc;
 
@@ -9,16 +9,17 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Client, Server};
 use hyper_rustls::TlsAcceptor;
 use rand::prelude::{SeedableRng, SmallRng};
-use rustls::server::ResolvesServerCertUsingSni;
-use rustls::sign::{any_supported_type, CertifiedKey};
 use tokio::sync::{Mutex, RwLock};
 
-use crate::config::TlsConfig;
+use crate::config::{TlsConfig, TlsSecrets};
 use crate::docker::client::DockerClient;
 use crate::reconciler::Reconciler;
 use crate::service_registry::ServiceRegistry;
 
+use self::tls::CertificateResolver;
+
 mod proxy;
+mod tls;
 
 #[derive(Debug)]
 pub struct LoadBalancer<C: DockerClient> {
@@ -69,7 +70,7 @@ impl<C: DockerClient + Sync + Send + 'static> LoadBalancer<C> {
         let reconciler = Arc::clone(&self.reconciler);
 
         if let Some(tls) = tls {
-            let acceptor = build_tls_acceptor(listener, tls).await?;
+            let acceptor = build_tls_acceptor(listener, tls.domains).await?;
             let server = Server::builder(acceptor);
 
             let service = make_service_fn(move |_| {
@@ -125,15 +126,11 @@ impl<C: DockerClient + Sync + Send + 'static> LoadBalancer<C> {
     }
 }
 
-async fn build_tls_acceptor(listener: TcpListener, tls: TlsConfig) -> Result<TlsAcceptor> {
-    let mut certificate_resolver = ResolvesServerCertUsingSni::new();
-
-    for (domain, secrets) in tls.domains {
-        let (cert, key) = secrets.resolve_files().await?;
-        let certified_key = parse_certified_key(&cert, &key)?;
-
-        certificate_resolver.add(&domain, certified_key)?;
-    }
+async fn build_tls_acceptor(
+    listener: TcpListener,
+    domains: HashMap<String, TlsSecrets>,
+) -> Result<TlsAcceptor> {
+    let certificate_resolver = CertificateResolver::new(&domains).await?;
 
     let config = rustls::ServerConfig::builder()
         .with_safe_defaults()
@@ -148,29 +145,6 @@ async fn build_tls_acceptor(listener: TcpListener, tls: TlsConfig) -> Result<Tls
         .with_incoming(incoming);
 
     Ok(acceptor)
-}
-
-fn parse_certified_key(cert: &[u8], key: &[u8]) -> Result<CertifiedKey> {
-    let mut cert = Cursor::new(cert);
-    let mut key = Cursor::new(key);
-
-    let cert: Vec<_> = rustls_pemfile::certs(&mut cert)?
-        .into_iter()
-        .map(rustls::Certificate)
-        .collect();
-
-    let keys = rustls_pemfile::pkcs8_private_keys(&mut key)?;
-    let key = rustls::PrivateKey(keys[0].clone());
-    let key = any_supported_type(&key)?;
-
-    let certified_key = CertifiedKey {
-        cert,
-        key,
-        ocsp: None,
-        sct_list: None,
-    };
-
-    Ok(certified_key)
 }
 
 #[cfg(test)]

--- a/src/load_balancer/tls.rs
+++ b/src/load_balancer/tls.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use color_eyre::eyre::Result;
+use rustls::server::{ClientHello, ResolvesServerCert};
+use rustls::sign::{any_supported_type, CertifiedKey};
+
+use crate::config::TlsSecrets;
+
+type Configuration = HashMap<String, TlsSecrets>;
+type Domains = HashMap<String, Arc<CertifiedKey>>;
+
+#[derive(Default)]
+pub struct CertificateResolver {
+    domains: ArcSwap<Domains>,
+}
+
+impl CertificateResolver {
+    pub async fn new(config: &Configuration) -> Result<Self> {
+        let mut resolver = Self::default();
+
+        resolver.discover(config).await?;
+
+        Ok(resolver)
+    }
+
+    pub async fn discover(&mut self, config: &Configuration) -> Result<()> {
+        let mut domains = HashMap::new();
+
+        for (domain, secrets) in config {
+            let (cert, key) = secrets.resolve_files().await?;
+            let certified_key = parse_certified_key(&cert, &key)?;
+
+            domains.insert(domain.to_owned(), Arc::new(certified_key));
+        }
+
+        self.domains.store(Arc::new(domains));
+
+        Ok(())
+    }
+}
+
+fn parse_certified_key(cert: &[u8], key: &[u8]) -> Result<CertifiedKey> {
+    let mut cert = Cursor::new(cert);
+    let mut key = Cursor::new(key);
+
+    let cert: Vec<_> = rustls_pemfile::certs(&mut cert)?
+        .into_iter()
+        .map(rustls::Certificate)
+        .collect();
+
+    let keys = rustls_pemfile::pkcs8_private_keys(&mut key)?;
+    let key = rustls::PrivateKey(keys[0].clone());
+    let key = any_supported_type(&key)?;
+
+    let certified_key = CertifiedKey {
+        cert,
+        key,
+        ocsp: None,
+        sct_list: None,
+    };
+
+    Ok(certified_key)
+}
+
+impl ResolvesServerCert for CertificateResolver {
+    fn resolve(&self, client_hello: ClientHello) -> Option<Arc<CertifiedKey>> {
+        let server_name = client_hello.server_name()?;
+        let domains = self.domains.load();
+
+        domains.get(server_name).cloned()
+    }
+}


### PR DESCRIPTION
The certificate handling at the moment just uses some inbuilt `rustls` types, but it would be nice to extend these and support automatic refreshing of certificates when they change in the configuration. Sharing the `CertificateResolver` around seems non-trivial, so this may require some channels to get working.

This change:
* Adds a custom `CertificateResolver` that behaves like the `rustls` type but understands where to grab certificates from
