### PR TITLE
feat: allow specifying container volumes

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -46,6 +46,7 @@ pub struct Container {
     pub image: String,
     pub target_port: u16,
     pub environment: Option<EncryptedEnvironment>,
+    pub volumes: HashMap<String, String>,
 }
 
 impl Container {
@@ -83,6 +84,7 @@ impl From<&Service> for Container {
             image: service.image.clone(),
             target_port: service.port,
             environment,
+            volumes: service.volumes.clone(),
         }
     }
 }
@@ -98,6 +100,7 @@ impl From<&AuxillaryService> for Container {
             image: service.image.clone(),
             target_port: service.port,
             environment,
+            volumes: Default::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,7 +156,7 @@ impl ExternalBytes {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
 pub struct Service {
     pub image: String,
     pub tag: String,
@@ -165,6 +165,7 @@ pub struct Service {
     pub host: String,
     pub path_prefix: Option<String>,
     pub environment: Option<HashMap<String, String>>,
+    pub volumes: HashMap<String, String>,
 }
 
 impl Hash for Service {
@@ -191,18 +192,7 @@ mod tests {
 
     fn some_config() -> Config {
         let mut services = HashMap::new();
-        services.insert(
-            String::from("backend"),
-            Service {
-                image: String::from("org/backend"),
-                tag: String::from("1"),
-                port: 5000,
-                replicas: 1,
-                host: String::from("example.com"),
-                path_prefix: None,
-                environment: None,
-            },
-        );
+        services.insert(String::from("backend"), Service::default());
 
         Config {
             alb: AlbConfig {
@@ -271,16 +261,7 @@ mod tests {
         let left = some_config();
         let mut right = left.clone();
 
-        let service = Service {
-            image: String::from("org/frontend"),
-            tag: String::from("latest"),
-            port: 80,
-            replicas: 1,
-            host: String::from("example.com"),
-            path_prefix: None,
-            environment: None,
-        };
-
+        let service = Service::default();
         right.services.insert("frontend".into(), service.clone());
 
         let diff = left.diff(&right);

--- a/src/docker/api.rs
+++ b/src/docker/api.rs
@@ -28,8 +28,11 @@ pub async fn create_and_start_container<C: DockerClient>(
     let target_port = container.target_port;
 
     let environment = container.decrypt_environment(private_key)?;
+    let volumes = &container.volumes;
 
-    let id = client.create_container(&name, &environment).await?;
+    let id = client
+        .create_container(&name, &environment, volumes)
+        .await?;
 
     client.start_container(&id).await?;
 

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
 use color_eyre::eyre::{self, Result};
@@ -21,6 +22,7 @@ pub trait DockerClient {
         &self,
         image: &str,
         environment: &Option<Environment>,
+        volumes: &HashMap<String, String>,
     ) -> Result<ContainerId>;
 
     async fn start_container(&self, id: &ContainerId) -> Result<()>;
@@ -79,6 +81,7 @@ impl DockerClient for Client {
         &self,
         image: &str,
         environment: &Option<Environment>,
+        volumes: &HashMap<String, String>,
     ) -> Result<ContainerId> {
         let uri = self.build_uri("/containers/create");
 
@@ -87,6 +90,7 @@ impl DockerClient for Client {
         let options = CreateContainerOptions {
             image: String::from(image),
             env,
+            volumes,
         };
 
         tracing::info!(%image, "Creating a container");

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::net::Ipv4Addr;
+use std::{collections::HashMap, fmt};
 
 use serde::{Deserialize, Serialize};
 
@@ -33,9 +33,10 @@ pub struct ImageSummary {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct CreateContainerOptions {
+pub struct CreateContainerOptions<'a> {
     pub image: String,
     pub env: Vec<String>,
+    pub volumes: &'a HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/load_balancer/tests.rs
+++ b/src/load_balancer/tests.rs
@@ -25,13 +25,10 @@ fn create_service<T: Into<Option<&'static str>>>(
     path_prefix: T,
 ) -> Service {
     Service {
-        image: String::from("account/application"),
-        tag: String::from("20220813-1803"),
         port,
-        replicas: 1,
         host: String::from(host),
         path_prefix: path_prefix.into().map(ToOwned::to_owned),
-        environment: None,
+        ..Default::default()
     }
 }
 

--- a/src/reconciler.rs
+++ b/src/reconciler.rs
@@ -216,7 +216,8 @@ pub mod tests {
         async fn create_container(
             &self,
             image: &str,
-            environment: &Option<Environment>,
+            _environment: &Option<Environment>,
+            _volumes: &HashMap<String, String>,
         ) -> Result<ContainerId> {
             let container_id = ContainerId::random();
 
@@ -227,11 +228,11 @@ pub mod tests {
             Ok(container_id)
         }
 
-        async fn start_container(&self, id: &ContainerId) -> Result<()> {
+        async fn start_container(&self, _id: &ContainerId) -> Result<()> {
             Ok(())
         }
 
-        async fn get_container_ip(&self, id: &ContainerId) -> Result<Ipv4Addr> {
+        async fn get_container_ip(&self, _id: &ContainerId) -> Result<Ipv4Addr> {
             Ok(Ipv4Addr::LOCALHOST)
         }
 
@@ -277,11 +278,8 @@ pub mod tests {
         let service = Service {
             image: image.to_owned(),
             tag: tag.to_owned(),
-            port: 5000,
             replicas: 1,
-            host: "localhost".to_owned(),
-            path_prefix: None,
-            environment: None,
+            ..Default::default()
         };
 
         let docker_client = FakeDockerClient::default();
@@ -318,7 +316,7 @@ pub mod tests {
         let docker_client = FakeDockerClient::default();
 
         let id = docker_client
-            .create_container(&format!("{image}:{tag}"), &None)
+            .create_container(&format!("{image}:{tag}"), &None, &HashMap::new())
             .await?;
 
         registry.add_container(
@@ -359,11 +357,8 @@ pub mod tests {
         let service_definition = Service {
             image: image.to_owned(),
             tag: tag.to_owned(),
-            port: 5000,
             replicas: 1,
-            host: String::new(),
-            path_prefix: None,
-            environment: None,
+            ..Default::default()
         };
 
         let mut altered_definition = service_definition.clone();
@@ -371,7 +366,7 @@ pub mod tests {
 
         let image_and_tag = format!("{image}:{tag}");
         let id = docker_client
-            .create_container(&image_and_tag, &None)
+            .create_container(&image_and_tag, &None, &HashMap::new())
             .await?;
 
         registry.define(service, service_definition);

--- a/src/service_registry.rs
+++ b/src/service_registry.rs
@@ -90,33 +90,12 @@ mod tests {
     use crate::docker::models::ContainerId;
     use crate::service_registry::ServiceRegistry;
 
-    fn some_service() -> Service {
-        Service {
-            image: String::from("repo/service"),
-            tag: String::from("latest"),
-            port: 8080,
-            replicas: 1,
-            host: String::from("example.com"),
-            path_prefix: None,
-            environment: None,
-        }
-    }
-
     #[test]
     fn can_store_and_fetch_service_definitions() {
         let mut registry = ServiceRegistry::new();
         let service = "backend";
 
-        let definition = Service {
-            image: String::from("repo/service"),
-            tag: String::from("latest"),
-            port: 8080,
-            replicas: 1,
-            host: String::from("example.com"),
-            path_prefix: None,
-            environment: None,
-        };
-
+        let definition = Service::default();
         registry.define(service, definition.clone());
 
         let found = registry.definitions.get(service);
@@ -128,7 +107,7 @@ mod tests {
     fn can_remove_service_definitions() {
         let mut registry = ServiceRegistry::new();
         let service = "backend";
-        let definition = some_service();
+        let definition = Service::default();
 
         registry.define(service, definition);
 
@@ -183,13 +162,10 @@ mod tests {
         path_prefix: Option<String>,
     ) {
         let service = Service {
-            image: String::from("something"),
-            tag: String::from("latest"),
-            port: 80,
             replicas: 1,
             host: String::from(host),
             path_prefix,
-            environment: None,
+            ..Default::default()
         };
 
         registry.define(name, service);


### PR DESCRIPTION
In order to get `vector` running on the `f2-instance` module, we'll need to be able to mount volumes to it for 2 reasons:

* It needs access to the Docker socket
* We'll need to pass some custom configuration

This change:
* Adds support for a `volumes` parameter on services
