### PR TITLE
feat: enforce non-zero replica counts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ async fn start_services<C: DockerClient>(
 
         tracing::info!("Starting {name} with tag {tag}");
 
-        for _ in 0..service.replicas {
+        for _ in 0..service.replicas.get() {
             let details = create_and_start_container(client, &container, tag, private_key).await?;
             service_registry.add_container(name, details);
         }

--- a/src/service_registry.rs
+++ b/src/service_registry.rs
@@ -162,7 +162,6 @@ mod tests {
         path_prefix: Option<String>,
     ) {
         let service = Service {
-            replicas: 1,
             host: String::from(host),
             path_prefix,
             ..Default::default()


### PR DESCRIPTION
It probably doesn't make much sense to have 0 replicas of a service (just remove it entirely if you need that) and if we have a constraint like that then we should aim to enforce it at the API level. Rust has a `NonZeroU8` type, so let's wrap that and provide a little extra functionality around it.

This change:
* Adds a `ReplicaCount` type
* Uses it everywhere it needs to be
