### PR TITLE
fix: defaults for environment and volumes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -193,7 +193,9 @@ pub struct Service {
     pub replicas: ReplicaCount,
     pub host: String,
     pub path_prefix: Option<String>,
-    pub environment: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub environment: HashMap<String, String>,
+    #[serde(default)]
     pub volumes: HashMap<String, String>,
 }
 
@@ -209,7 +211,8 @@ pub struct AuxillaryService {
     pub image: String,
     pub tag: String,
     pub port: u16,
-    pub environment: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub environment: HashMap<String, String>,
 }
 
 #[cfg(test)]
@@ -272,7 +275,7 @@ mod tests {
         let mut environment = HashMap::new();
         environment.insert("NEW_PROPERTY".into(), "some-value".into());
 
-        right.services.get_mut("backend").unwrap().environment = Some(environment);
+        right.services.get_mut("backend").unwrap().environment = environment;
 
         let diff = left.diff(&right);
 


### PR DESCRIPTION
`f2` is failing to start up on the new version since the `volumes` property doesn't exist. It isn't actually required (plenty of containers won't have associated volumes) so let's just default to an empty `HashMap` if we don't find the property.

Turns out we can do this for the `environment` as well, so let's tidy up the code a little bit.

This change:
* Annotates `environment` and `volumes` with `#[serde(default)]`
* Updates the code to handle all this
