### PR TITLE
refactor: improve tests

### DIFF
--- a/src/health.rs
+++ b/src/health.rs
@@ -90,7 +90,6 @@ mod tests {
         let requests = Arc::new(AtomicU32::new(1));
         let behaviour = Arc::new(behaviour);
 
-        // service responds with 2 500s and then a 200
         let service = make_service_fn(move |_| {
             let requests = Arc::clone(&requests);
             let behaviour = Arc::clone(&behaviour);


### PR DESCRIPTION
The health checking tests have a lot of boilerplate at the moment as some of them want to return 200s and 500s at different points. Let's extract some common code that does this and update all the tests to be a bit cleaner.

This change:
* Refactors a `spawn_server` method which allows custom behaviour to be defined based on the number of requests processed
* Updates all the tests to use this instead
