### PR TITLE
feat: add mTLS support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::net::Ipv4Addr;
 use std::num::NonZeroU8;
@@ -104,6 +104,7 @@ pub struct AlbConfig {
     pub port: u16,
     pub reconciliation: String,
     pub tls: Option<TlsConfig>,
+    pub mtls: Option<MtlsConfig>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -129,6 +130,14 @@ impl TlsSecrets {
 
         Ok((cert, key))
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+pub struct MtlsConfig {
+    /// The certificate to use as the trust anchor when validating incoming requests.
+    pub anchor: ExternalBytes,
+    /// The domains to apply mTLS to.
+    pub domains: HashSet<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -232,6 +241,7 @@ mod tests {
                 port: 5000,
                 reconciliation: String::new(),
                 tls: None,
+                mtls: None,
             },
             secrets: None,
             services,

--- a/src/load_balancer/tests.rs
+++ b/src/load_balancer/tests.rs
@@ -101,6 +101,7 @@ async fn spawn_load_balancer(service_registry: ServiceRegistry) -> Result<Socket
                         port: 5000,
                         reconciliation: String::from("/reconciliation"),
                         tls: None,
+                        mtls: None,
                     },
                     secrets: None,
                     services: HashMap::new(),
@@ -111,7 +112,7 @@ async fn spawn_load_balancer(service_registry: ServiceRegistry) -> Result<Socket
         );
 
         load_balancer
-            .start(listener, None)
+            .start(listener, None, None)
             .await
             .expect("Failed to run load balancer");
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ async fn main() -> Result<()> {
     let addr = config.alb.addr;
     let port = config.alb.port;
     let tls = config.alb.tls.clone();
+    let mtls = config.alb.mtls.clone();
 
     let mut service_registry = ServiceRegistry::new();
     let private_key = config.get_private_key().await?;
@@ -83,7 +84,7 @@ async fn main() -> Result<()> {
     let listener = TcpListener::bind(SocketAddrV4::new(addr, port)).await?;
     let mut load_balancer = LoadBalancer::new(service_registry, &reconciliation_path, reconciler);
 
-    load_balancer.start(listener, tls).await?;
+    load_balancer.start(listener, tls, mtls).await?;
 
     Ok(())
 }

--- a/src/reconciler.rs
+++ b/src/reconciler.rs
@@ -254,6 +254,7 @@ pub mod tests {
                 port: 5000,
                 reconciliation: String::new(),
                 tls: None,
+                mtls: None,
             },
             secrets: None,
             services: HashMap::new(),


### PR DESCRIPTION
Now that we've deployed the upgrade to the latest version of `hyper`, we can start looking at supporting mTLS for some domains.

The general approach here is just to take an anchor certificate that all the downstream ones must be signed by (this will be the self-signed root one) and some domains where we should check for authentication.

This change:
* Adds an optional section to the configuration
* Updates the usages to read the certificate and apply the correct protocols per domain
