### PR TITLE
feat: use common name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "mutual-tls"
 version = "0.1.0"
-source = "git+https://github.com/alexander-jackson/mutual-tls.git?rev=efeb451#efeb4510aeda45aecd9a532f5237ac2e632d1a25"
+source = "git+https://github.com/alexander-jackson/mutual-tls.git?rev=012b3d5#012b3d595a73d6462767200acd4c510900ad60cb"
 dependencies = [
  "argh",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hyper-util = { version = "0.1.9", features = ["client", "client-legacy", "http1"
 hyperlocal = "0.9.1"
 indexmap = "2.2.6"
 itertools = "0.13.0"
-mutual-tls = { git = "https://github.com/alexander-jackson/mutual-tls.git", rev = "efeb451", version = "0.1.0" }
+mutual-tls = { git = "https://github.com/alexander-jackson/mutual-tls.git", rev = "012b3d5", version = "0.1.0" }
 pico-args = "0.5.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rsa = "0.9.6"

--- a/src/load_balancer/mod.rs
+++ b/src/load_balancer/mod.rs
@@ -127,7 +127,7 @@ impl<C: DockerClient + Sync + Send + 'static> LoadBalancer<C> {
                 let (stream, _) = listener.accept().await?;
                 let io = TokioIo::new(stream);
 
-                let service = service_factory(ConnectionContext { unit: None });
+                let service = service_factory(ConnectionContext { common_name: None });
 
                 tokio::spawn(async move {
                     if let Err(e) = Builder::new(TokioExecutor::new())


### PR DESCRIPTION
As we prepare to deploy mTLS to production and start using it, we need to think about the certificates that get generated. In line with what has been seen before, the common name attribute is used for human-readable identifiers on the certificates.

This change:
* Updates `mutual-tls` to use common name over organisational unit
