### PR TITLE
feat: remove auxillary services

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt};
 use color_eyre::eyre::{eyre, Result, WrapErr};
 use rsa::RsaPrivateKey;
 
-use crate::config::{AuxillaryService, Service};
+use crate::config::Service;
 use crate::crypto::decrypt;
 
 #[derive(Clone)]
@@ -78,19 +78,6 @@ impl From<&Service> for Container {
                 variables: service.environment.clone(),
             },
             volumes: service.volumes.clone(),
-        }
-    }
-}
-
-impl From<&AuxillaryService> for Container {
-    fn from(service: &AuxillaryService) -> Self {
-        Self {
-            image: service.image.clone(),
-            target_port: service.port,
-            environment: EncryptedEnvironment {
-                variables: service.environment.clone(),
-            },
-            volumes: Default::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,6 @@ pub struct Config {
     pub alb: AlbConfig,
     pub secrets: Option<SecretConfig>,
     pub services: HashMap<String, Service>,
-    pub auxillary_services: Option<Vec<AuxillaryService>>,
 }
 
 impl Config {
@@ -215,15 +214,6 @@ impl Hash for Service {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
-pub struct AuxillaryService {
-    pub image: String,
-    pub tag: String,
-    pub port: u16,
-    #[serde(default)]
-    pub environment: HashMap<String, String>,
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -245,7 +235,6 @@ mod tests {
             },
             secrets: None,
             services,
-            auxillary_services: None,
         }
     }
 

--- a/src/load_balancer/tests.rs
+++ b/src/load_balancer/tests.rs
@@ -105,7 +105,6 @@ async fn spawn_load_balancer(service_registry: ServiceRegistry) -> Result<Socket
                     },
                     secrets: None,
                     services: HashMap::new(),
-                    auxillary_services: None,
                 },
                 FakeDockerClient::default(),
             ),

--- a/src/reconciler.rs
+++ b/src/reconciler.rs
@@ -258,7 +258,6 @@ pub mod tests {
             },
             secrets: None,
             services: HashMap::new(),
-            auxillary_services: None,
         };
 
         Reconciler::new(


### PR DESCRIPTION
These aren't particularly useful at the moment, since `f2` doesn't actually pick up changes for them and live services can't guarantee what IP they'll be listening on anyway.

In the future we can re-add these in a more sensible way for running things like caches, but we'll need some way of routable services knowing where to find them (likely through DNS).

This change:
* Removes the concept of auxillary to reduce the complexity
