### PR TITLE
deps: upgrade everything

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,28 +7,28 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.7.1"
-async-trait = "0.1.81"
-aws-config = "1.5.4"
-aws-sdk-s3 = "1.42.0"
+async-trait = "0.1.83"
+aws-config = "1.5.9"
+aws-sdk-s3 = "1.59.0"
 base64 = "0.22.1"
 chrono = "0.4.38"
 color-eyre = "0.6.3"
-futures = "0.3.30"
+futures = "0.3.31"
 http = "1.1.0"
 http-body-util = "0.1.2"
 hyper = "1.5.0"
-hyper-util = { version = "0.1.9", features = ["client", "client-legacy", "http1", "http2", "server"] }
+hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1", "http2", "server"] }
 hyperlocal = "0.9.1"
-indexmap = "2.2.6"
+indexmap = "2.6.0"
 itertools = "0.13.0"
 mutual-tls = { git = "https://github.com/alexander-jackson/mutual-tls.git", rev = "d9691d8", version = "0.1.0" }
 pico-args = "0.5.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rsa = "0.9.6"
-rustls = { version = "0.23.15", default-features = false, features = ["ring", "std"] }
+rustls = { version = "0.23.16", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = "2.2.0"
-serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde = { version = "1.0.214", features = ["derive"] }
+serde_json = "1.0.132"
 serde_yaml = "0.9.33"
 tokio = { version = "1.41.0", features = ["macros", "rt-multi-thread", "time", "fs"] }
 tracing = "0.1.40"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.67-rust-1.80.0-alpine3.20 AS chef
+FROM lukemathwalker/cargo-chef:0.1.68-rust-1.82.0-alpine3.20 AS chef
 
 WORKDIR /app
 


### PR DESCRIPTION
All of the dependencies were updated in the last change so this does very little except align them in `Cargo.toml`.

This change:
* Aligns `Cargo.toml` with the latest versions
* Bumps the Dockerfile versions
