### PR TITLE
feat: use lowercase for shutdown mode

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -196,6 +196,7 @@ impl Deref for ReplicaCount {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ShutdownMode {
     Graceful,
     Forceful,


### PR DESCRIPTION
The `ShutdownMode` currently deserialises from `Graceful`, but it should probably use `graceful` for nicer formatting.

This change:
* Adds the required annotation
