### PR TITLE
fix: stop using volumes

### DIFF
--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -107,7 +107,7 @@ impl DockerClient for Client {
         let options = CreateContainerOptions {
             image: String::from(image),
             env,
-            volumes,
+            volumes: &HashMap::new(),
             host_config,
         };
 


### PR DESCRIPTION
The Docker documentation specifies:

Volumes are not a good choice if you need to access the files from the host, as the volume is completely managed by Docker. Use bind mounts if you need to access files or directories from both containers and the host.

This might be the reason that we're seeing odd behaviour on the server, and everything seems to be fine locally so it's worth trying out.

This change:
* Stops using volumes when creating containers
