### PR TITLE
deps: bump `mutual-tls`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "mutual-tls"
 version = "0.1.0"
-source = "git+https://github.com/alexander-jackson/mutual-tls.git?rev=981ee61#981ee6137de7166e29b8f185dd2f02756442e752"
+source = "git+https://github.com/alexander-jackson/mutual-tls.git?rev=43b6e71#43b6e71ebec75a67938c7958ad61cf4d643cfef2"
 dependencies = [
  "color-eyre",
  "http 1.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1
 hyperlocal = "0.9.1"
 indexmap = "2.7.0"
 itertools = "0.14.0"
-mutual-tls = { git = "https://github.com/alexander-jackson/mutual-tls.git", rev = "981ee61", version = "0.1.0" }
+mutual-tls = { git = "https://github.com/alexander-jackson/mutual-tls.git", rev = "43b6e71", version = "0.1.0" }
 pico-args = "0.5.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rsa = "0.9.7"


### PR DESCRIPTION
Various improvements have been made to the `mutual-tls` crate which are worth picking up as the API gets better.

This change:
* Bumps to the latest version and handles the breaking changes
