### PR TITLE
chore: reduce log level

### DIFF
--- a/src/load_balancer/proxy.rs
+++ b/src/load_balancer/proxy.rs
@@ -63,7 +63,7 @@ pub async fn handle_request<C: DockerClient>(
 
     let path_and_query = uri.path_and_query().map_or("/", PathAndQuery::as_str);
 
-    tracing::info!(%downstream, %path_and_query, "Proxing request to a downstream server");
+    tracing::debug!(%downstream, %path_and_query, "proxing request to a downstream server");
 
     let addr = SocketAddrV4::new(downstream, port);
     *req.uri_mut() = format!("http://{addr}{path_and_query}").parse()?;


### PR DESCRIPTION
This logging message is basically all that `f2` ever outputs (since it is done for every request). At some point we will export all these as proper traces with way more information, but for now let's cool down the logging.

This change:
* Reduces the logging level to debug
