### PR TITLE
feat: support proper networking

### DIFF
--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Ensure the `mesh` network exists, create it if it doesn't
-docker network inspect mesh >/dev/null 2>&1 || docker network create --driver bridge mesh
+# Ensure the `internal` network exists, create it if it doesn't
+docker network inspect internal >/dev/null 2>&1 || docker network create --driver bridge internal
 
 docker run -it \
 	-p 3000:3000 \
@@ -10,6 +10,6 @@ docker run -it \
 	-v ./forkup.yaml:/app/forkup.yaml \
 	-v /tmp:/tmp \
 	-v /var/run/docker.sock:/var/run/docker.sock \
-	--network mesh \
+	--network internal \
 	--env-file .env \
 	f2:debug -- --config /tmp/config.yaml

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
+use std::fmt;
 use std::net::Ipv4Addr;
-use std::{collections::HashMap, fmt};
 
 use serde::{Deserialize, Serialize};
 
@@ -7,6 +8,15 @@ use serde::{Deserialize, Serialize};
 pub struct ContainerId(pub String);
 
 impl fmt::Display for ContainerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
+pub struct NetworkId(pub String);
+
+impl fmt::Display for NetworkId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -38,12 +48,29 @@ pub struct CreateContainerOptions<'a> {
     pub env: Vec<String>,
     pub volumes: &'a HashMap<String, HashMap<String, String>>,
     pub host_config: HostConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub networking_config: Option<NetworkingConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct HostConfig {
     pub binds: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct NetworkingConfig {
+    pub endpoints_config: HashMap<String, EndpointConfig>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct EndpointConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aliases: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -61,6 +88,19 @@ pub struct InspectContainerResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct NetworkSettings {
+    pub networks: HashMap<String, NetworkInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct NetworkInfo {
     #[serde(rename = "IPAddress")]
     pub ip_address: Ipv4Addr,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Network {
+    pub id: String,
+    pub name: String,
 }


### PR DESCRIPTION
Currently, containers cannot talk to each other and are isolated on the network. `vector` works around this by finding containers itself, but it would be nice to ship all of our OpenTelemetry data over somewhere and have that run as a separate container.

This change:
* Begins starting containers in a network called `internal`
