### PR TITLE
refactor: remove container names

### DIFF
--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -33,7 +33,6 @@ pub trait DockerClient {
         image: &str,
         environment: &Option<Environment>,
         docker_volumes: &HashMap<String, String>,
-        hostname: Option<&str>,
         network: Option<(&NetworkId, &str)>,
     ) -> Result<ContainerId>;
 
@@ -127,7 +126,6 @@ impl DockerClient for Client {
         image: &str,
         environment: &Option<Environment>,
         docker_volumes: &HashMap<String, String>,
-        hostname: Option<&str>,
         network: Option<(&NetworkId, &str)>,
     ) -> Result<ContainerId> {
         let uri = self.build_uri("/containers/create");
@@ -164,7 +162,6 @@ impl DockerClient for Client {
             volumes: &HashMap::new(),
             host_config,
             networking_config,
-            hostname: hostname.map(|s| s.to_owned()),
         };
 
         let body = serde_json::to_vec(&options)?;

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -50,8 +50,6 @@ pub struct CreateContainerOptions<'a> {
     pub host_config: HostConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networking_config: Option<NetworkingConfig>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hostname: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/reconciler.rs
+++ b/src/reconciler.rs
@@ -248,7 +248,6 @@ pub mod tests {
             image: &str,
             _environment: &Option<Environment>,
             _docker_volumes: &HashMap<String, String>,
-            _hostname: Option<&str>,
             _network: Option<(&NetworkId, &str)>,
         ) -> Result<ContainerId> {
             let container_id = ContainerId::random();
@@ -367,7 +366,6 @@ pub mod tests {
                 &format!("{image}:{tag}"),
                 &None,
                 &HashMap::new(),
-                None,
                 Some((&NetworkId("mesh".to_owned()), "foobar.local")),
             )
             .await?;
@@ -422,7 +420,6 @@ pub mod tests {
                 &image_and_tag,
                 &None,
                 &HashMap::new(),
-                None,
                 Some((&NetworkId("mesh".to_owned()), "foobar.local")),
             )
             .await?;


### PR DESCRIPTION
These don't actually seem to be used for anything, so let's remove them.

This change:
* Tidies up the code a little bit
