### PR TITLE
feat: support multiple servers

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -98,10 +98,17 @@ impl Config {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Protocol {
+    Http,
+    Https,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
 pub struct AlbConfig {
     pub addr: Ipv4Addr,
-    pub port: u16,
+    pub ports: HashMap<Protocol, u16>,
     pub reconciliation: String,
     pub tls: Option<TlsConfig>,
     pub mtls: Option<MtlsConfig>,
@@ -253,7 +260,7 @@ mod tests {
     use std::collections::HashMap;
     use std::net::Ipv4Addr;
 
-    use crate::config::{AlbConfig, Config, Diff, Service};
+    use crate::config::{AlbConfig, Config, Diff, Protocol, Service};
 
     fn some_config() -> Config {
         let mut services = HashMap::new();
@@ -262,7 +269,7 @@ mod tests {
         Config {
             alb: AlbConfig {
                 addr: Ipv4Addr::LOCALHOST,
-                port: 5000,
+                ports: HashMap::from([(Protocol::Http, 5000)]),
                 reconciliation: String::new(),
                 tls: None,
                 mtls: None,

--- a/src/load_balancer/mod.rs
+++ b/src/load_balancer/mod.rs
@@ -1,15 +1,22 @@
+use std::collections::HashMap;
+use std::error::Error;
 use std::io::Cursor;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
+use async_trait::async_trait;
 use color_eyre::eyre::Result;
-use hyper::body::Incoming;
-use hyper::service::service_fn;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use http::{Request, Response};
+use http_body_util::combinators::BoxBody;
+use hyper::body::{Bytes, Incoming};
+use hyper::service::{service_fn, Service};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder;
-use mutual_tls::{ConnectionContext, ServerConfiguration};
+use mutual_tls::{ConnectionContext, Server, ServerConfiguration};
 use rand::prelude::{SeedableRng, SmallRng};
 use rustls::server::danger::ClientCertVerifier;
 use rustls::server::{NoClientAuth, WebPkiClientVerifier};
@@ -18,7 +25,7 @@ use tls::DynamicAuthenticationLevelResolver;
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, RwLock};
 
-use crate::config::{Config, MtlsConfig, TlsConfig};
+use crate::config::{Config, MtlsConfig, Protocol, TlsConfig};
 use crate::ipc::MessageBus;
 use crate::load_balancer::tls::CertificateResolver;
 use crate::service_registry::ServiceRegistry;
@@ -55,7 +62,7 @@ impl LoadBalancer {
 
     pub async fn run(
         self,
-        listener: TcpListener,
+        mut listeners: HashMap<Protocol, TcpListener>,
         tls: Option<TlsConfig>,
         mtls: Option<MtlsConfig>,
     ) -> Result<()> {
@@ -90,60 +97,150 @@ impl LoadBalancer {
             })
         };
 
-        if let Some(tls) = tls {
-            let client_cert_verifier: Arc<dyn ClientCertVerifier> = match &mtls {
-                Some(config) => {
-                    let bytes = config.anchor.resolve().await?;
-                    let mut cursor = Cursor::new(bytes);
+        let servers = FuturesUnordered::new();
 
-                    let mut store = RootCertStore::empty();
-                    let certs = rustls_pemfile::certs(&mut cursor).filter_map(Result::ok);
-                    let (added, ignored) = store.add_parsable_certificates(certs);
+        if let Some(listener) = listeners.remove(&Protocol::Http) {
+            let server = HttpServer::new(service_factory.clone());
 
-                    tracing::info!(%added, %ignored, "set up the trust store");
+            tracing::info!("starting http server on {}", listener.local_addr()?);
 
-                    WebPkiClientVerifier::builder(Arc::new(store)).build()?
-                }
-                None => Arc::new(NoClientAuth),
-            };
+            servers.push(server.run(listener));
+        }
 
-            let config = Arc::new(tls.domains);
-            let message_bus = Arc::clone(&self.message_bus);
+        if let Some(listener) = listeners.remove(&Protocol::Https) {
+            if let Some(tls) = tls {
+                let client_cert_verifier: Arc<dyn ClientCertVerifier> = match &mtls {
+                    Some(config) => {
+                        let bytes = config.anchor.resolve().await?;
+                        let mut cursor = Cursor::new(bytes);
 
-            let certificate_resolver =
-                Arc::new(CertificateResolver::new(config, message_bus).await?);
-            let authentication_level_resolver =
-                DynamicAuthenticationLevelResolver::new(Arc::clone(&self.config));
+                        let mut store = RootCertStore::empty();
+                        let certs = rustls_pemfile::certs(&mut cursor).filter_map(Result::ok);
+                        let (added, ignored) = store.add_parsable_certificates(certs);
 
-            let server_configuration = ServerConfiguration::default();
-            let server = mutual_tls::Server::new(
-                authentication_level_resolver,
-                client_cert_verifier,
-                certificate_resolver,
-                service_factory,
-                server_configuration,
-            );
+                        tracing::info!(%added, %ignored, "set up the trust store");
 
-            server.run(listener).await;
-        } else {
-            loop {
-                let (stream, _) = listener.accept().await?;
-                let io = TokioIo::new(stream);
-
-                let service = service_factory(ConnectionContext { common_name: None });
-
-                tokio::spawn(async move {
-                    if let Err(e) = Builder::new(TokioExecutor::new())
-                        .serve_connection(io, service)
-                        .await
-                    {
-                        tracing::warn!(%e, "error handling connection");
+                        WebPkiClientVerifier::builder(Arc::new(store)).build()?
                     }
-                });
+                    None => Arc::new(NoClientAuth),
+                };
+
+                let config = Arc::new(tls.domains);
+                let message_bus = Arc::clone(&self.message_bus);
+
+                let certificate_resolver =
+                    Arc::new(CertificateResolver::new(config, message_bus).await?);
+                let authentication_level_resolver =
+                    DynamicAuthenticationLevelResolver::new(Arc::clone(&self.config));
+
+                let server_configuration = ServerConfiguration::default();
+                let server = Server::new(
+                    authentication_level_resolver,
+                    client_cert_verifier,
+                    certificate_resolver,
+                    service_factory,
+                    server_configuration,
+                );
+
+                tracing::info!("starting https server on {}", listener.local_addr()?);
+
+                servers.push(server.run(listener));
             }
         }
 
+        servers
+            .for_each(|result| async move {
+                tracing::info!("server completed: {:?}", result);
+            })
+            .await;
+
         Ok(())
+    }
+}
+
+#[async_trait]
+trait ConnectionHandler: Send + Sync {
+    async fn run(self, listener: TcpListener);
+}
+
+pub struct HttpServer<F> {
+    service_factory: Arc<F>,
+}
+
+impl<F, S> HttpServer<F>
+where
+    F: Fn(ConnectionContext) -> S + Send + Sync + 'static,
+    S: Service<Request<Incoming>, Response = Response<BoxBody<Bytes, hyper::Error>>>
+        + Send
+        + 'static,
+    S::Future: 'static,
+    <S as Service<Request<Incoming>>>::Future: Send,
+    <S as Service<Request<Incoming>>>::Error: Into<Box<dyn Error + Send + Sync>>,
+{
+    pub fn new(service_factory: F) -> Self {
+        Self {
+            service_factory: Arc::new(service_factory),
+        }
+    }
+
+    pub async fn try_handle_connection(
+        &self,
+        listener: &mut TcpListener,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
+
+        let service = (self.service_factory)(ConnectionContext { common_name: None });
+
+        tokio::spawn(async move {
+            if let Err(e) = Builder::new(TokioExecutor::new())
+                .serve_connection(io, service)
+                .await
+            {
+                tracing::warn!(%e, "error handling connection");
+            }
+        });
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<F, S> ConnectionHandler for HttpServer<F>
+where
+    F: Fn(ConnectionContext) -> S + Send + Sync + 'static,
+    S: Service<Request<Incoming>, Response = Response<BoxBody<Bytes, hyper::Error>>>
+        + Send
+        + 'static,
+    S::Future: 'static,
+    <S as Service<Request<Incoming>>>::Future: Send,
+    <S as Service<Request<Incoming>>>::Error: Into<Box<dyn Error + Send + Sync>>,
+{
+    async fn run(self, mut listener: TcpListener) {
+        loop {
+            if let Err(e) = self.try_handle_connection(&mut listener).await {
+                tracing::warn!(%e, "failed to handle connection");
+            } else {
+                tracing::trace!("handled a connection from a client");
+            }
+        }
+    }
+}
+
+// implement ConnectionHandler for Server
+#[async_trait]
+impl<F, S> ConnectionHandler for Server<F>
+where
+    F: Fn(ConnectionContext) -> S + Send + Sync + 'static,
+    S: Service<Request<Incoming>, Response = Response<BoxBody<Bytes, hyper::Error>>>
+        + Send
+        + 'static,
+    S::Future: 'static,
+    <S as Service<Request<Incoming>>>::Future: Send,
+    <S as Service<Request<Incoming>>>::Error: Into<Box<dyn Error + Send + Sync>>,
+{
+    async fn run(self, listener: TcpListener) {
+        self.run(listener).await;
     }
 }
 

--- a/src/load_balancer/tls.rs
+++ b/src/load_balancer/tls.rs
@@ -162,7 +162,7 @@ mod tests {
     use rustls::pki_types::pem::PemObject;
     use rustls::pki_types::CertificateDer;
 
-    use crate::config::{AlbConfig, Config, ExternalBytes, MtlsConfig, TlsSecrets};
+    use crate::config::{AlbConfig, Config, ExternalBytes, MtlsConfig, Protocol, TlsSecrets};
     use crate::ipc::MessageBus;
     use crate::load_balancer::tls::{CertificateResolver, DynamicAuthenticationLevelResolver};
 
@@ -176,7 +176,7 @@ mod tests {
 
         let alb = AlbConfig {
             addr: Ipv4Addr::LOCALHOST,
-            port: 5000,
+            ports: HashMap::from([(Protocol::Http, 5000)]),
             reconciliation: String::new(),
             tls: None,
             mtls: Some(MtlsConfig {

--- a/src/reconciler.rs
+++ b/src/reconciler.rs
@@ -212,7 +212,7 @@ pub mod tests {
     use tokio::sync::RwLock;
 
     use crate::common::Environment;
-    use crate::config::{AlbConfig, Config, Diff, ExternalBytes, ReplicaCount, Service};
+    use crate::config::{AlbConfig, Config, Diff, ExternalBytes, Protocol, ReplicaCount, Service};
     use crate::docker::api::StartedContainerDetails;
     use crate::docker::client::DockerClient;
     use crate::docker::models::{ContainerId, ImageSummary, NetworkId};
@@ -293,7 +293,7 @@ pub mod tests {
         let config = Config {
             alb: AlbConfig {
                 addr: Ipv4Addr::LOCALHOST,
-                port: 5000,
+                ports: HashMap::from([(Protocol::Http, 5000)]),
                 reconciliation: String::new(),
                 tls: None,
                 mtls: None,


### PR DESCRIPTION
For the `telemetry` instance, we're going to want to accept HTTP traffic from the live instance to process metrics and traces. As such, we need to be able to run HTTPS (for viewing the frontend) and HTTP (for handling telemetry).

This change:
* Adds support for running multiple servers, one HTTP and one HTTPS, on different ports
