### PR TITLE
feat: support multiple hosts

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -44,7 +44,6 @@ pub struct Environment {
 #[derive(Clone)]
 pub struct Container {
     pub image: String,
-    pub target_port: u16,
     pub environment: EncryptedEnvironment,
     pub volumes: HashMap<String, VolumeDefinition>,
 }
@@ -53,7 +52,7 @@ impl fmt::Debug for Container {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Container")
             .field("image", &self.image)
-            .field("target_port", &self.target_port)
+            .field("volumes", &self.volumes)
             .finish()
     }
 }
@@ -62,7 +61,6 @@ impl From<&Service> for Container {
     fn from(service: &Service) -> Self {
         Self {
             image: service.image.clone(),
-            target_port: service.port,
             environment: EncryptedEnvironment {
                 variables: service.environment.clone(),
             },

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,14 +224,20 @@ impl Default for ShutdownMode {
     }
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize)]
+pub struct Route {
+    pub host: String,
+    pub prefix: Option<String>,
+    pub port: u16,
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
 pub struct Service {
     pub image: String,
     pub tag: String,
-    pub port: u16,
     pub replicas: ReplicaCount,
-    pub host: String,
-    pub path_prefix: Option<String>,
+    #[serde(default)]
+    pub routes: HashSet<Route>,
     #[serde(default)]
     pub environment: HashMap<String, String>,
     #[serde(default)]

--- a/src/docker/api.rs
+++ b/src/docker/api.rs
@@ -27,7 +27,6 @@ pub async fn create_and_start_container<C: DockerClient>(
 ) -> Result<StartedContainerDetails> {
     let Container {
         image,
-        target_port,
         environment,
         volumes,
     } = &container;
@@ -58,7 +57,7 @@ pub async fn create_and_start_container<C: DockerClient>(
 
     client.start_container(&id).await?;
 
-    tracing::info!(%id, %name, %target_port, %hostname, "created and started a container");
+    tracing::info!(%id, %name, %hostname, "created and started a container");
 
     // Get the container itself and the port details
     let addr = client.get_container_ip(&id).await?;

--- a/src/load_balancer/tests.rs
+++ b/src/load_balancer/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ use hyper_util::server::conn::auto::Builder;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 
-use crate::config::{AlbConfig, Config, Protocol, Service};
+use crate::config::{AlbConfig, Config, Protocol, Route, Service};
 use crate::docker::api::StartedContainerDetails;
 use crate::docker::models::ContainerId;
 use crate::ipc::MessageBus;
@@ -29,9 +29,11 @@ fn create_service<T: Into<Option<&'static str>>>(
     path_prefix: T,
 ) -> Service {
     Service {
-        port,
-        host: String::from(host),
-        path_prefix: path_prefix.into().map(ToOwned::to_owned),
+        routes: HashSet::from([Route {
+            host: String::from(host),
+            prefix: path_prefix.into().map(ToOwned::to_owned),
+            port,
+        }]),
         ..Default::default()
     }
 }

--- a/src/load_balancer/tests.rs
+++ b/src/load_balancer/tests.rs
@@ -253,3 +253,86 @@ async fn can_proxy_downstream_based_on_path_prefixes() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn can_proxy_to_different_ports_based_on_route_configuration() -> Result<()> {
+    let internal_reply = "Hello from the internal service";
+    let external_reply = "Hello from the external service";
+
+    let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
+    let internal_listener = TcpListener::bind(&addr).await?;
+    let internal_addr = internal_listener.local_addr()?;
+
+    let external_listener = TcpListener::bind(&addr).await?;
+    let external_addr = external_listener.local_addr()?;
+
+    tokio::spawn(async move {
+        loop {
+            // handle a connection on the internal service, then on the external service
+            let (stream, _) = internal_listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+
+            tokio::spawn(async move {
+                Builder::new(TokioExecutor::new())
+                    .serve_connection(io, service_fn(move |_| handler(internal_reply)))
+                    .await
+                    .unwrap();
+            });
+
+            let (stream, _) = external_listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+
+            tokio::spawn(async move {
+                Builder::new(TokioExecutor::new())
+                    .serve_connection(io, service_fn(move |_| handler(external_reply)))
+                    .await
+                    .unwrap();
+            });
+        }
+    });
+
+    // 2 services on the same host, different paths
+    let name = "opentracker";
+    let internal_host = "internal.opentracker.app";
+    let external_host = "external.opentracker.app";
+    let mut service_registry = ServiceRegistry::new();
+
+    let service = Service {
+        routes: HashSet::from([
+            Route {
+                host: String::from(internal_host),
+                prefix: None,
+                port: internal_addr.port(),
+            },
+            Route {
+                host: String::from(external_host),
+                prefix: None,
+                port: external_addr.port(),
+            },
+        ]),
+        ..Default::default()
+    };
+
+    service_registry.define(name, service);
+
+    add_container(&mut service_registry, name);
+
+    let addr = spawn_load_balancer(service_registry).await?;
+    let client = Client::builder(TokioExecutor::new()).build_http();
+
+    let request = Request::builder()
+        .uri(format!("http://{}/", addr))
+        .header(HOST, internal_host)
+        .body(Full::default())?;
+
+    assert_eq!(get_response_body(&client, request).await?, internal_reply);
+
+    let request = Request::builder()
+        .uri(format!("http://{}/", addr))
+        .header(HOST, external_host)
+        .body(Full::default())?;
+
+    assert_eq!(get_response_body(&client, request).await?, external_reply);
+
+    Ok(())
+}


### PR DESCRIPTION
In order to expose HyperDX internally and externally, we'll need to proxy multiple hosts into the same container but with different ports. Internal clients will need to talk to the 4318 port to export traces, whereas external clients will need to talk to the 8080 port to handle regular requests from the frontend.

This change:
* Supports multiple hosts with different port mappings
