### PR TITLE
fix: avoid recursive futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "mutual-tls"
 version = "0.1.0"
-source = "git+https://github.com/alexander-jackson/mutual-tls.git?rev=43b6e71#43b6e71ebec75a67938c7958ad61cf4d643cfef2"
+source = "git+https://github.com/alexander-jackson/mutual-tls.git?rev=e5a36c5#e5a36c5d47ab60afed3b7f1748097cb463cbfeb5"
 dependencies = [
  "color-eyre",
  "http 1.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1
 hyperlocal = "0.9.1"
 indexmap = "2.7.0"
 itertools = "0.14.0"
-mutual-tls = { git = "https://github.com/alexander-jackson/mutual-tls.git", rev = "43b6e71", version = "0.1.0" }
+mutual-tls = { git = "https://github.com/alexander-jackson/mutual-tls.git", rev = "e5a36c5", version = "0.1.0" }
 pico-args = "0.5.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rsa = "0.9.7"


### PR DESCRIPTION
The implementation of `ConnectionHandler` for `mutual_tls::Server` was calling itself recursively, which caused a segmentation fault whenever HTTPS was enabled.

Claude both wrote this and debugged it, so...

This change:
* Avoids doing that
* Bumps `mutual_tls` to make `Server::run` consume it
* Removes `ConnectionHandler` entirely and uses `JoinSet` instead
