### PR TITLE
feat: handle shutdown better

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rustls-pemfile = "2.2.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.135"
 serde_yaml = "0.9.33"
-tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread", "time", "fs"] }
+tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread", "time", "fs", "signal"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 uuid = { version = "1.17.0", features = ["v4"] }


### PR DESCRIPTION
When running in Docker, `f2` doesn't really handle the shutdown signals and this makes it difficult to debug locally.

This change:
* Adds signal handling to terminate it more gracefully
