### PR TITLE
feat: tidy up containers and images

### DIFF
--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -13,8 +13,9 @@ use serde::de::DeserializeOwned;
 
 use crate::common::Environment;
 use crate::docker::models::{
-    CreateContainerOptions, CreateContainerResponse, EndpointConfig, HostConfig, ImageSummary,
-    InspectContainerResponse, Network, NetworkId, NetworkingConfig,
+    ContainerPruneResponse, CreateContainerOptions, CreateContainerResponse, EndpointConfig,
+    HostConfig, ImagePruneResponse, ImageSummary, InspectContainerResponse, Network, NetworkId,
+    NetworkingConfig,
 };
 
 use super::models::ContainerId;
@@ -43,6 +44,8 @@ pub trait DockerClient {
     async fn stop_container(&self, id: &ContainerId) -> Result<()>;
 
     async fn remove_container(&self, id: &ContainerId) -> Result<()>;
+
+    async fn prune_unused_containers_and_images(&self) -> Result<()>;
 }
 
 pub struct Client {
@@ -255,6 +258,43 @@ impl DockerClient for Client {
             .body(Full::default())?;
 
         self.client.request(request).await?;
+
+        Ok(())
+    }
+
+    async fn prune_unused_containers_and_images(&self) -> Result<()> {
+        let containers_uri = self.build_uri("/containers/prune");
+        let images_uri = self.build_uri("/images/prune");
+
+        tracing::info!("pruning unused containers");
+
+        let request = Request::builder()
+            .uri(containers_uri)
+            .method(Method::POST)
+            .body(Full::default())?;
+
+        let response = self.client.request(request).await?;
+        let body: ContainerPruneResponse = deserialize_body(response).await?;
+
+        tracing::info!(
+            containers_deleted = ?body.containers_deleted,
+            space_reclaimed = body.space_reclaimed,
+            "pruned unused containers"
+        );
+
+        let request = Request::builder()
+            .uri(images_uri)
+            .method(Method::POST)
+            .body(Full::default())?;
+
+        let response = self.client.request(request).await?;
+        let body: ImagePruneResponse = deserialize_body(response).await?;
+
+        tracing::info!(
+            images_deleted = ?body.images_deleted,
+            space_reclaimed = body.space_reclaimed,
+            "pruned unused images"
+        );
 
         Ok(())
     }

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -102,3 +102,25 @@ pub struct Network {
     pub id: String,
     pub name: String,
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ImagePruneResponse {
+    pub images_deleted: Option<Vec<ImageDeleted>>,
+    pub space_reclaimed: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(dead_code)]
+pub struct ImageDeleted {
+    pub deleted: String,
+    pub untagged: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContainerPruneResponse {
+    pub containers_deleted: Vec<String>,
+    pub space_reclaimed: u64,
+}

--- a/src/reconciler.rs
+++ b/src/reconciler.rs
@@ -147,6 +147,11 @@ impl<C: DockerClient> Reconciler<C> {
             }
         }
 
+        // remove any old containers and images
+        self.docker_client
+            .prune_unused_containers_and_images()
+            .await?;
+
         Ok(())
     }
 
@@ -177,6 +182,11 @@ impl<C: DockerClient> Reconciler<C> {
                 self.docker_client.remove_container(&details.id).await?;
             }
         }
+
+        // remove any old containers and images
+        self.docker_client
+            .prune_unused_containers_and_images()
+            .await?;
 
         Ok(())
     }
@@ -283,6 +293,10 @@ pub mod tests {
 
         async fn get_network_by_name(&self, _name: &str) -> Result<Option<NetworkId>> {
             Ok(Some(NetworkId("mesh".to_owned())))
+        }
+
+        async fn prune_unused_containers_and_images(&self) -> Result<()> {
+            Ok(())
         }
     }
 


### PR DESCRIPTION
If the instance last a long time, we can be keeping quite a lot of images around on it that are no longer being used.

This change:
* Prunes the containers and images whenever we reconcile and roll a service or remove it
