### PR TITLE
feat: add logging for Docker calls

### DIFF
--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -307,8 +307,17 @@ async fn deserialize_body<T>(response: Response<Incoming>) -> Result<T>
 where
     T: DeserializeOwned,
 {
+    let status = response.status();
+
+    tracing::debug!(%status, "deserializing response body");
+
     let bytes = read_body(response).await?;
     let decoded = std::str::from_utf8(&bytes)?;
+
+    if !status.is_success() {
+        eyre::bail!("request failed with status code {status} and body: {decoded}",);
+    }
+
     let json = serde_json::from_str(decoded)?;
 
     Ok(json)


### PR DESCRIPTION
At the moment, `f2` presumes that all Docker calls will succeed and thus has very little error handling here outside of `?` propagation. It should at least consider the status code and provide more detailed messages when something goes wrong.

This change:
* Adds some debug logging for the response status
* Checks to see if it is successful and returns an error if not
